### PR TITLE
feat(04_Interacting_with_Lean.org): add draft of chapter 4

### DIFF
--- a/04_Interacting_with_Lean.org
+++ b/04_Interacting_with_Lean.org
@@ -1,0 +1,527 @@
+#+Author: [[http://www.andrew.cmu.edu/user/avigad][Jeremy Avigad]]
+#+HTML_HEAD: <link rel='stylesheet' href='css/tutorial.css'>
+#+HTML_HEAD_EXTRA:<link rel='stylesheet' href='css/jquery-ui.css'>
+#+HTML_HEAD_EXTRA:<script src='js/platform.js'></script>
+#+HTML_HEAD_EXTRA:<script src='js/jquery-1.10.2.js'></script>
+#+HTML_HEAD_EXTRA:<script src='js/jquery-ui.js'></script>
+#+HTML_HEAD_EXTRA:<link rel='import' href='juicy-ace-editor.html'>
+#+HTML_HEAD_EXTRA:<link rel='stylesheet' href='css/code.css'>
+#+OPTIONS: toc:nil
+#+Title: Theorem Proving in Lean
+
+* Interacting with Lean
+
+You are now familiar with the fundamentals of dependent type theory,
+both as a language for defining mathematical objects and a language
+for constructing proofs. The one thing you are missing is a mechanism
+for defining new data types. We will fill this gap in the next chapter,
+which introduces the notion of an /inductive/ data type. But first, in
+this chapter, we take a break from the mechanics of type theory to
+explore pragmatic aspects of interaction with Lean.
+
+** Querying Lean for Information
+
+There are a number of ways in which you can query Lean for information
+about its current state and the defined objects and theorems that are
+available in the current context. You have already seen two of the
+most common ones, =check= and =eval=. We remind you that =eval= is
+often used in conjunction with the =@= operator, which makes all of
+the arguments to a theorem or definition explicit. In addition, Lean
+offers a =print definition= command, that shows the value of a defined
+symbol.
+
+#+BEGIN_SRC lean
+import data.nat
+
+-- examples with equality
+check eq
+check @eq
+check eq.symm
+check @eq.symm
+
+print definition eq.symm
+
+-- examples with and
+check and
+check and.intro
+check @and.intro
+
+-- examples with addition
+open nat
+check add
+check @add
+eval add 3 2
+print definition add
+
+-- a user-defined function
+definition foo {A : Type} (x : A) : A := x
+
+check foo
+check @foo
+eval foo
+eval (foo @nat.zero)
+print definition foo
+#+END_SRC
+
+Note that =print definition= only works with objects introduced with
+=definition=, =theorem=, and the like. For example, entering =print
+definition eq= or =print definition and.intro= yields an error. This
+is because =eq= and =and.intro= are not defined symbols, but, rather,
+symbols introduced axiomatically by the Lean's inductive definition
+package, which we will describe in the next chapter.
+
+Another useful command, although the implementation is still
+rudimentary at this stage, is the =find decl= command. This can be
+used to find theorems whose conclusion matches a given pattern. 
+The syntax is as follows:
+#+BEGIN_SRC text
+find_decl <pattern>  [, filter]*
+#+END_SRC
+where =<pattern>= is just an expression with "holes" (underscores),
+and a filter is of the form
+#+BEGIN_SRC text
++ id  (id is a substring of the declaration)
+- id  (id is not a substring of the declaration) 
+  id  (id is a substring of the declaration)
+#+END_SRC
+For example:
+#+BEGIN_SRC lean
+import data.nat
+
+open nat
+find_decl ((_ * _) = (_ * _))
+find_decl (_ * _) = _, +assoc
+find_decl (_ * _) = _, -assoc
+
+find_decl _ < succ _, +imp, -le
+#+END_SRC
+
+
+** Setting Options
+
+Lean also maintains a number of internal variables that can be set by
+users to control its behavior. The syntax is
+#+BEGIN_SRC text
+set option <name> <value>
+#+END_SRC
+
+One very useful family of options controls the way Lean's /pretty-
+printer/ displays terms. The following options take an input of true
+or false:
+
+#+BEGIN_SRC text
+pp.implicit : display implicit arguments
+pp.universes : display hidden universe parameters
+pp.coercions : show coercions
+pp.notation : display output using defined notations
+#+END_SRC
+
+In Lean, /coercions/ can be inserted automatically to cast an element
+of one data type to another, for example, to cast an element of =nat=
+to an element of =int=. We will discuss coercions in a later
+chapter. This list is not exhaustive; you can see a complete list by
+typing =set_option pp.= and then using tab-completion in the Emacs
+mode for Lean, discussed below.
+
+As an example, the following settings yield much longer output:
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+set_option pp.implicit true
+set_option pp.universes true
+set_option pp.notation false
+set_option pp.numerals false
+
+check 2 + 2 = 4
+eval (λx, x + 2) = (λx, x + 3)
+#+END_SRC
+
+Pretty printing additional information is often very useful when you
+are debugging a proof, or trying to understand a cryptic error
+message. Too much information can be overwhelming, though, and Lean's
+defaults are generally sufficient for ordinary interactions.
+
+
+** Using the Library
+
+To use Lean effectively you will inevitably need to make use of
+definitions and theorems in the library. Recall that the =import=
+command at the beginning of a file imports previously compiled results
+from other files, and that importing is transitive; if you import
+=foo= and =foo= imports =bar=, then the definitions and theorems from
+=bar= are available to you as well. But the act of opening a namespace
+-- which provides shorter names, notations, rewrite rules, and more --
+does not carry over. In each file, you need to open the namespaces you
+wish to use.
+
+For many purposes, =import standard= and =open standard= will give you
+a good set of defaults. Even so, it is important for you to be
+familiar with the library and its contents, so you know what theorems,
+definitions, notations, and resources are available to you. Below we
+will see that Lean's Emacs mode can also help you find things you
+need, but studying the contents of the library directly is often
+unavoidable.
+
+Lean has two libraries. Here we will focus on the standard
+library, which offers a conventional mathematical farmework. We will
+discuss the library for homotopy type theory in a later chapter. 
+
+There are a number of ways to explore the contents of the standard
+library. You can find the file structure online, on github:
+#+BEGIN_CENTER
+[[https://github.com/leanprover/lean/tree/master/library]]
+#+END_CENTER
+You can see the contents of the directories and files using github's
+browser interface. If you have installed Lean on your own computer,
+you can find the library in the =lean= folder, and explore it
+with your file manager. Comment headers at the top of each file
+provide additional information.
+
+Alternatively, there are "markdown" files in the library that provide
+links to the same files but list them in a more natural order, and
+provide additional information and annotations.
+#+BEGIN_CENTER
+[[https://github.com/leanprover/lean/blob/master/library/library.md]]
+#+END_CENTER
+You can again browse these through the github interface, or with a
+markdown reader on your computer.
+
+Lean's library developers follow general naming guidelines to make
+it easier to guess the name of a theorem you need, or to find it using
+tab completion in Lean's Emacs mode, which is discussed in the next
+section. To start with, common "axiomatic" properties of an operation
+like conjunction or multiplication are put in a namespace that begins
+with the name of the operation:
+
+#+BEGIN_SRC lean
+import standard algebra.ordered_ring
+open nat algebra
+
+check and.comm
+check mul.comm
+check and.assoc
+check mul.assoc
+check @mul.left_id
+check succ.inj -- successor is injective
+check @mul.left_cancel -- multiplication is left cancelative
+#+END_SRC
+
+In particular, this includes =intro= and =elim= operations for logical
+connectives, and properties of relations:
+
+#+BEGIN_SRC lean
+import standard algebra.ordered_ring
+open nat algebra
+
+-- BEGIN
+check and.intro
+check and.elim
+check or.intro_left
+check or.intro_right
+check or.elim
+
+check eq.refl
+check eq.symm
+check eq.trans
+-- END
+#+END_SRC
+
+For the most part, however, we rely on descriptive names. Often the
+name of theorem simply describes the conclusion:
+
+#+BEGIN_SRC lean
+import standard algebra.ordered_ring
+open nat algebra
+
+-- BEGIN
+check succ_ne_zero
+check @mul_zero_eq
+check @sub_add_eq_add_sub
+check @le_iff_lt_or_eq
+-- END
+#+END_SRC
+
+If only a prefix of the description is enough to convey the meaning,
+the name may be made even shorter:
+
+#+BEGIN_SRC lean
+import standard algebra.ordered_ring
+open nat algebra
+
+-- BEGIN
+check @neg_neg_eq   -- TO DO: will be neg_neg
+check pred.succ     -- TO DO: will be pred_succ
+-- END
+#+END_SRC
+
+Sometimes, to disambiguate the name of theorem or better convey the
+intended reference, it is necessary to describe some of the
+hypotheses. The word "of" is used to separate these hypotheses:
+
+#+BEGIN_SRC lean
+import standard algebra.ordered_ring
+open nat algebra
+
+-- BEGIN
+check lt_of_succ_le
+check @lt_of_not_le
+check @lt_of_le_of_ne
+check @add_lt_add_of_lt_of_lt
+-- END
+#+END_SRC
+
+Sometimes abbreviations or alternative descriptions are easier to work
+with. For example, we use =pos=, =neg=, =nonpos=, =nonneg= rather than
+=zero_lt=, =lt_zero=, =le_zero=, and =zero_le=.
+
+#+BEGIN_SRC lean
+import standard algebra.ordered_ring
+open nat algebra
+
+-- BEGIN
+check @mul_pos_of_pos_of_pos
+check @mul_nonpos_of_nonneg_of_nonpos
+check @add_lt_of_lt_of_nonpos
+check @add_lt_of_nonpos_of_lt
+-- END
+#+END_SRC
+
+Sometimes the word "left" or "right" is helpful to describe variants
+of a theorem.
+
+#+BEGIN_SRC lean
+import standard algebra.ordered_ring
+open nat algebra
+
+-- BEGIN
+check @add_le_add_left
+check @add_le_add_right
+check @le_of_mul_le_mul_left
+check @le_of_mul_le_mul_right
+-- END
+#+END_SRC
+
+
+** Lean's Emacs Mode
+
+This tutorial is designed to be read alongside Lean's web-browser
+interface, which runs a Javascript-compiled version of Lean inside
+your web browser. But there is a much more powerful interface to Lean
+that runs as a special mode in the Emacs text editor. Our goal in this
+section is to consider some of the advantages and features of the
+Emacs interface.
+
+If you have never used the Emacs text editor before, you should spend
+some time experimenting with it. Emacs is an extremely powerful text
+editor, but it can also be overwhelming. There are a number of
+introductory tutorials on the web, including these:
+#+BEGIN_CENTER
+[[http://www.gnu.org/software/emacs/tour/]]
+
+[[http://www.jesshamrick.com/2012/09/10/absolute-beginners-guide-to-emacs/]]
+
+http://www.ucs.cam.ac.uk/docs/course-notes/unix-courses/earlier/Emacs/files/course.pdf
+#+END_CENTER
+But you can get pretty far simply using the menus at the top of the
+screen for basic editing and file management. Those menus list
+keyboard-equivalents for the commands. Notation like "C-x", short for
+"control x," means "hold down the control key while typing x." The
+notation "M-x", short for "Meta x," means "hold down the Alt key while
+typing x," or, equivalently, "press the Esc key, followed by x." For
+example, the "File" menu lists "C-c C-s" as a keyboard-equivalent for
+the save file command.
+
+There are a number of benefits to using Emacs instead of the web
+interface. Perhaps the most important is file management. The web interface
+imports the entire standard library internally, which is why some
+examples in this tutorial have to put examples in a namespace, "hide,"
+to avoid conflicting with objects already defined in the standard
+library.  Moreover, the web interface only operates on one file at a
+time. Using the Emacs editor, you can create and edit Lean theory
+files anywhere on your file system, as with any editor or word
+processor. From these files, you can import pieces of the library at
+will, as well as your own theories, defined in separate files.
+
+To use the Emacs with Lean, you simply need to create a file with the
+extension ".lean" and edit it. (For files that should be checked in
+the homotopy type theory framework, use ".hlean" instead.) For
+example, you can create a file by typing =emacs my_file.lean= in a
+terminal window, in the directory where you want to keep the
+file. Assuming everything has been installed correctly, Emacs will
+start up in Lean mode, already checking your (still empty) file in the
+background.
+
+You can then start typing, or copy any of the examples in this
+tutorial. (In the latter case, make sure you include the =import= and
+=open= commands that are sometimes hidden in the html.) Lean mode
+offers syntax highlighting, so command, identifiers, and so on are
+helpfullly color-coded. Any errors that Lean detects are subtly
+underlined in red, and the editor displays an exclamation mark in the
+left margin. As you continue to type and eliminate errors, these
+annotations magically disappear.
+
+If you put the cursor on a highlighted error, Emacs displays the error
+message in at the bottom of the frame. Alteratively, if you type "C-c
+! l" while in Lean mode, Emacs opens a new window with a list of
+compilation errors.
+
+It may be disconcerting to see a perfectly good proof suddenly "break"
+when you change a single character. If this proof is in the middle of
+a file you are working on, the Lean interface will moreover raise an
+error at every subsequent reference to the theorem. But these complaints
+vanish as soon as the correctness of the theorem is restored. Lean is
+quite fast and caches previous work to speed up compilation, and
+changes you make are registered almost instantaneously.
+
+The Emacs Lean mode maintains a continuous dialog with a background
+Lean process and uses it to present useful information to you. For
+example, if you put your cursor on any identifier -- a theorem name, a
+defined symbol, or a variable -- Emacs displays the its type in the
+information line at the bottom. If you put the cursor on the openening
+parenthesis of an expression, Emacs displays the type of the
+expression.
+
+This works even for implicit arguments. If you put your cursor on an
+underscore symbol, then, assuming Lean's elaborator was successful in
+inferring the value, Emacs shows you that value and its type. Typing
+"C-c C-f" replaces the inferred value with the underscore. In cases
+where Lean is unable to infer a value of an implicit argument, the
+underscore is highlighted, and the error message indicates the type of
+the "hole" that needs to be filled. This can be extremely useful when
+constructing proofs incrementally. One can start typing a "proof
+sketch," using either =sorry= or an underscore for details you intend
+to fill in later. Assuming the proof is correct modulo these missing
+pieces of information, the error message at an unfilled underscore
+tells you the type of the term you need to construct, typically an
+assertion you need to justify.
+
+The Lean mode supports tab completion. In a context where Lean expects
+an identifier (e.g. a theorem name or a defined symbol), if you start
+typing and then hit the tab key, a popup window suggests possible
+matches or near-matches for the expression you have typed. This helps
+you find the theorems you need without having to browse the library.
+
+If you put your cursor on an identifier that is defined in Lean's
+library and hit "M-.", Emacs will take you to the identifier's
+definition in the library file itself. This works even in an
+autocompletion popup window: if you start typing an identifier, press
+the tab key, choose a completion from the list of options, and press
+"M-.", you are taken to the symbol's definition. These commands and
+others are summarized here:
+#+BEGIN_CENTER
+[[https://github.com/leanprover/lean/blob/master/src/emacs/README.md]]
+#+END_CENTER
+
+This is a good place to mention another trick that is sometimes useful
+when editing long files. In Lean, the "exit" command halts processing
+of the file and returns. If you are making changes at the top of a
+long file and want to defer checking of the remainder of the file
+until you are done making those changes, you can temporarily insert an
+"exit".
+
+
+** Working with Multiple Files
+
+Working with multiple files is only slightly more complex than working
+with a development that fits into a single file. From Lean's
+perspective, processing an input file is a matter of constructing
+terms in the calculus of constructions, filling in the values of
+implicit arguments if necessary. These terms can then be saved,
+typically in a file with the same name but the extension ".olean", a
+Lean "object" file. It is these files that are loaded by the "import"
+command.
+
+To start a project that may, potentially, involve more than one file,
+choose the folder where you want the project to reside, open an
+initial file in Emacs, and choose "create a new project" from the Lean
+menu. The default file the system suggests is fine for most purposes,
+and you can just press the "open" button. This step enables a
+background process to ensure that whenever you are working on a file
+in this folder, compiled versions of all the files it depends on are
+available and up to date.
+
+Suppose you are editing =foo.lean=, which imports on =bar.lean=. You
+can switch to =bar= and make additions or corrections to that file,
+then switch back to =foo= and continue working. The process =linja=,
+based on the =ninja= build system, ensures that =bar= is recompiled
+and that an up-to-date version is available to =foo=.
+
+Whenever you enter =import foo= at the top of a =.lean= file, Lean
+searches both the library directory and the current directory for
+=foo.lean=. If you want to specify that the location of =foo= is
+relative to the current directory, type =import .foo=. It is perfectly
+o.k. if your project folder has subfolders, as long as the build file
+-- the one you created with "create project" -- sits at the top. To
+import =foo= from folder =bar= relative to the current directory, type
+=import .bar.foo=. To import =foo= from folder =bar= in the parent of
+the current directory, type =import ..bar.foo=, and so on.
+
+Incidentally, outside of Emacs, from a terminal window, you can type
+=linja= anywhere in your project folder to ensure that all your files
+have compiled, =.olean= counterparts, and that they are up to date.
+
+
+** Defining Notation
+
+Lean's parser is an instance of a Pratt parser, a non-backtracking
+parser that is fast and flexible. You can read about Pratt parsers in
+a number of places online, such as here:
+#+BEGIN_CENTER
+[[http://en.wikipedia.org/wiki/Pratt_parser]]
+
+[[http://eli.thegreenplace.net/2010/01/02/top-down-operator-precedence-parsing]]
+#+END_CENTER
+Identifiers can include any alphanumeric characters, including Greek
+characters (other than Π, Σ, and λ, which, as we have seen, have a
+special meaning in the dependent type theory). They can also include
+subscripts, which can be entered by typing "\_" followed
+by the desired subscripted character.
+
+Lean's parser is moreover extensible, which is to say, we can define
+new notation.
+
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+notation `[` a `**` b `]` := a * b + 1
+
+definition mul_square (a b : ℕ) := a * a * b * b
+
+infix `<*>`:50 := mul_square
+
+eval [2 ** 3]
+eval 2 <*> 3
+#+END_SRC
+
+In this example, the =notation= command defines a complex binary
+notation for multiplying and adding one. The =infix= command declares
+a new infix operator, with precedence 50, which associates to the
+left. (More precisely, the token is given left-binding power 50.) The
+command =infixr= defines notation which associates to the right,
+instead. 
+
+If you declare these notations in a namespace, the notation is only
+operant when the namespace is open. You can declare temporary notation
+using the keyword "[local]", in which case the notation is operant
+only in the current file.
+
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+-- BEGIN
+notation [local] `[` a `**` b `]` := a * b + 1
+infix [local] `<*>`:50 := λa b : ℕ, a * a * b * b
+-- END
+#+END_SRC
+
+The file =reserved_notation.lean= in the =init= folder of the library
+declares the left-binding powers of a number of common symbols that
+are used in the library. 
+#+BEGIN_CENTER
+https://github.com/leanprover/lean/blob/master/library/init/reserved_notation.lean
+#+END_CENTER
+You are welcome to overload these symbols for your own use, but you
+cannot change their right-binding power.


### PR DESCRIPTION
It is not carefully proofread and still needs work, but it is a start.

I tried to cover the most fundamental aspects of interaction with Lean. I ran out of energy when writing about the parser, and there are probably things we should talk about under "setting options". Please let me know if you can think of other things I should add.

Also, let me know if you have suggestions about the markup I am using. I used "#+BEGIN_SRC text" for blocks that are not Lean code, but they still generate the "Try it Yourself" button. I also used "#+BEGIN_CENTER" for displaying web links, but maybe there is something else I should use.

This week I will spend time cleaning up name of theorems in the library, adding comments to headers, and updating the markdown directory files. After that I can revise some of the examples in this chapter.

I think the next two chapters should be

  Chapter 5: Inductive Types
    Enumerated Types
    Option Type and Subtypes
    Inductive Structures
      nat
      list
      binary trees
      countably branching trees
    Inductive families

  Chapter 6: Structuring Theories and Proofs
    Structuring Long Proofs (proof ... qed, "visible", etc.)
    Sections and Contexts 
    Using Tactics

I am not sure whether the function definition package should be described in Chapter 5 as we go, or whether it should be a separate chapter.

It just occurred to me that I should split the "Using the Library" section of this chapter into two, "Using the Library" and "Naming Conventions". I will do that later.
