### PR TITLE
revised Chapter 8

### DIFF
--- a/08_Building_Theories_and_Proofs.org
+++ b/08_Building_Theories_and_Proofs.org
@@ -15,50 +15,68 @@ briefly, and noted that there are restrictions on the types that one
 can coerce from and to. Now that we have discussed inductive types in
 the Calculus of Constructions, we can be more precise.
 
-First, let us introduce some terminology. An ordinary /class/ is an
-inductive datatype. An inductive data type without parameters or
-indices, like =nat= or =bool=, has only one instance. (So =nat= and
-=bool= are both classes and instances.) Inductive types with
-parameters and/or indices have multiple instances; for example, =list
-nat= and =list bool= are both instances of the class list. There are
-also two special classes, namely, the class of /sorts/, whose
-instances are =Type.{i}= for the various values of =i=, and the class
-of /function types/, whose instances are the Pi types.
+The most basic type of coercion maps elements of one type to
+another. For example, a coercion from =nat= to =int= allows us to view
+any element =n : nat= as an element of =int=. But some coercions
+depend on parameters; for example, for any type =A=, we can view any
+element =l : list A= as an element of =set A=, namely, the set of
+elements occurring in the list. This corresponding coercion is defined
+on the "family" of types =list A=, parameterized by =A=.
 
-Lean allows users to define three kinds of coercions:
-+ coercions from a class to another class
-+ coercions from a class to the class of sorts
-+ coercions from a class to the class of function types.
-A coercion of the first kind takes any element of an instance =A1= of
-the first class to an element of an instance =A2= of the second
-class. A coercion of the second kind takes any element of =A1= to a
-type. A coercion of the third kind takes any element of =A1= to a
-function. Let us consider each of these in turn.
+In fact, Lean allows us to declare three kinds of coercions:
++ from a family of types to another family of types
++ from a family of types to the class of sorts
++ from a family of types to the class of function types
+The first kind of coercion allows us to view any element of a member
+of the source family as an element of a corresponding member of the
+target family. The second kind of coercion allows us to view any
+element of a member of the source family as a type. The third kind of
+coercion allows us to view any element of the source family as a function.
+Let us consider each of these in turn.
 
-# TODO: should we use the terminology "instance"? It is confusing
-# because we also say, e.g., =nat.ring= is an instance of =Ring=.
+In type theory terminology, an element =F : Πx1 : A1, ..., xn : An,
+Type= is called a /family of types/. For every sequence of arguments
+=a1 : A1, ..., an : An=, =F a1 ... an= is a type, so we think of =F=
+as being a family parameterized by these arguments. A coercion of the
+first kind is of the form
+#+BEGIN_SRC text
+c : Πx1 : A1, ..., xn : An, y : F x1 ... xn, G b1 ... bm
+#+END_SRC
+where =G= is another famly of types, and the terms =b1 ... bn= depend
+on =x1, ..., xn, y=. This allows us to write =f t= where =t= is of
+type =F a1 ... an= but =f= expects an argument of type =G y1 ... ym=,
+for some =y1 ... ym=. For example, if =F= is =list : ΠA : Type, Type=,
+=G= is =set ΠA : Type, Type=, then a coercion =c : ΠA : Type, list A →
+set A= allows us to pass an argument of type =list T= for some =T= any
+time an element of type =set T= is expected. These are the types of
+coercions we considered in Section [[Notation, Overloads, and Coercions]].
 
-The first type of coercion allows us to write =f a= where =f= has type
-=Πx : A1, B x=, =a= has type =A2=, and =A1= and =A2= are instances of
-classes =C1= and =C2=, respectively. The idea is that the coercion
-from =C1= to =C2= tells us how to any element of an instance of =C1=
-as an element of a corresponding instance of =C2=. A standard example
-is the coercion from the class =nat= to the class =int=, which enables
-us to view any element of =nat= as an element of =int= via the usual
-embedding. Another example is the coercion from the class =list= to
-the class =set=, which tells us how to view any element of =list A= as
-an element of =set A= by taking the set of elements that occur in the
-list. These are the types of coercions we considered in Section
-[[Notation, Overloads, and Coercions]].
+Lean imposes the restriction that the source and target families have
+to be families of inductive types, as defined in Chapter [[Inductive
+Types]]. Note that these include parameterized structures, as discussed
+in the next chapter. Because inductive types are atomic --- they do
+not unfold, definitionally, to other expressions --- this reduces
+ambiguity and makes it easier for Lean's elaborator to determine when
+to consider a coercion. This restriction turns out to be mild in
+practice: most natural sources and targets for coercions are defined
+as inductive types, and any type =T= can be "wrapped" as an inductive
+type, by writing ~inductive foo (T : Type) := mk : T → foo~.
 
 # TODO: give Lean source for these examples.
 
-The second type of coercion, from a class =C= to =sort=, allows us to
-write =x : t= whenever =t= belongs to an instance of a class each of whose
-elements can be associated with a =Type=. We will see in
-a later chapter that this is very useful when defining algebraic
-structures in which one component, the carrier of the structure, is a
-=Type=. For example, we can define a semigroup as follows:
+Let us now consider the second kind of coercion. By the /class of
+sorts/, we mean the collection of universes =Type.{i}=. A coercion of
+the second kind is of the form 
+#+BEGIN_SRC text
+c : Πx1 : A1, ..., xn : An, F x1 ... xn → Type
+#+END_SRC
+where =F= is a family of types as above. This allows
+us to write =s : t= whenever =t= is of type =F a1 ... an=. In other
+words, the coercion allows us to view the elements of =F a1 ... an= as
+types. We will see in a later chapter that this is very useful when
+defining algebraic structures in which one component, the carrier of
+the structure, is a =Type=. For example, we can define a semigroup as
+follows:
 #+BEGIN_SRC lean
 structure Semigroup : Type :=
 (carrier : Type)
@@ -106,10 +124,17 @@ example (S : Semigroup) (a b : S) : a * b * a = a * (b * a) :=
 #+END_SRC
 It is the coercion that makes it possible to write =(a b : S)=.
 
-The third type of coercion makes it possible to write =t a= where =t=
-belongs to an instance of a class whose elements can be viewed as
-functions. Continuing the example above, we can define the notion of a
-morphism between semigroups:
+By the /class of function types/, we mean the collection of Pi types
+=Πz : B, C=. The third kind of coercion has the form
+#+BEGIN_SRC text
+c : Πx1 : A1, ..., xn : An, y : F x1 ... xn, Πz : B, C
+#+END_SRC
+where =F= is again a family of types and =B= and =C= can depend on
+=x1, ..., xn, y=. This makes it possible to write =t s= whenever =t=
+is an element of =F a1 ... an=. In other words, the coercion enables
+us to view elements of =F a1 ... an= as functions. Continuing the
+example above, we can define the notion of a morphism between
+semigroups:
 #+BEGIN_SRC lean
 structure Semigroup : Type :=
 (carrier : Type)
@@ -239,11 +264,12 @@ print coercions
 #+END_SRC
 
 Lean will also chain coercions as necessary. You can think of the
-coercion declarations as forming a directed graph where the nodes are classes
-and the edges are the coercions between them. More precisely, the
-nodes are ordinary classes, plus two special classes, =sort-class=
-and =fun-class=, which are sinks in the graph. Internally, Lean
-automatically computes the transitive closure of this graph.
+coercion declarations as forming a directed graph where the nodes are
+families of types and the edges are the coercions between them. More
+precisely, each node is either a family of types, or the class of
+sorts, of the class of function types. The latter two are sinks in the
+graph. Internally, Lean automatically computes the transitive closure
+of this graph, in which the "paths" correspond to chains of coercions.
 
 ** Elaboration and Unification
 
@@ -254,13 +280,13 @@ notation =+= may be overloaded, and there may be implicit arguments to
 =f= that need to be filled in as well.
 
 The process of taking a partially-specified expression and inferring
-what is left implicit is known as /elaboration/. Lean's
-elaboration algorithm is powerful, but at the same time, subtle and
+what is left implicit is known as /elaboration/. Lean's elaboration
+algorithm is powerful, but at the same time, subtle and
 complex. Working in a system of dependent type theory requires knowing
 what sorts of information the elaborator can reliably infer, as well
 as knowing how to respond to error messages that are raised when the
-elaborator fails. To that end, it will be helpful to have a general
-idea of how Lean's elaborator works.
+elaborator fails. To that end, it is helpful to have a general idea of
+how Lean's elaborator works.
 
 When Lean is parsing an expression, it first enters a preprocessing
 phase. First, the "holes" in a term --- the unspecified values --- are
@@ -308,7 +334,7 @@ solutions:
 - =λx y, f (g x) y b=
 - =λx y, f (g a) b y=
 - =λx y, f (g a) b b=
-Notice that such problems in many ways, such as:
+Such problems arise in many ways. For example:
 - When you use =induction_on x= for an inductively defined type, Lean
   has to infer the relevant induction predicate.
 - When you write =eq.subst e p= with an equation =e : a = b= to
@@ -347,57 +373,7 @@ The interaction of computation with higher-order unification is
 particularly knotty. For the most part, Lean avoids peforming
 computational reduction when trying to solve higher-order
 constraints. You can override this, however, by marking some symbols
-as =reducible=. This is one of a number of ways of providing hints to
-the elaboration process. To tell the elaborator to consider reducing
-=foo= when solving higher-order unification problems, use the
-=reducible= command:
-#+BEGIN_SRC lean
-import standard
-
-definition foo (x : nat) : nat := x
-
--- BEGIN
-reducible foo
--- END
-#+END_SRC
-To turn off this hint, use the =irreducible= command:
-#+BEGIN_SRC lean
-import standard
-
-definition foo (x : nat) : nat := x
-
--- BEGIN
-irreducible foo
--- END
-#+END_SRC
-As with coercions, the "scope" of these hints is only until the end of
-the module (i.e., the file) that contain them. To make the effect
-persist in modules that import the one in which they are declared, use
-the =persistent= modifier:
-#+BEGIN_SRC lean
-import standard
-
-definition foo (x : nat) : nat := x
-
--- BEGIN
-reducible [persistent] foo
-irreducible [persistent] foo
--- END
-#+END_SRC
-You can alternatively declare a symbol to be reducible when you define
-it:
-#+BEGIN_SRC lean
-import standard
-
-definition foo [reducible] (x : nat) : nat := x
-#+END_SRC
-This has the same effect as the following:
-#+BEGIN_SRC lean
-import standard
-
-definition foo (x : nat) : nat := x
-reducible [persistent] foo
-#+END_SRC
+as =reducible=, as decribed in Section [[Reducible Definitions]].
 
 The elaborator relies on additional tricks and gadgets to solve a list
 of constraints and instantiate metavariables. Below we will see that
@@ -429,6 +405,178 @@ of the remaining metavariables as "placeholders" or "goals" that could
 not be filled.
 
 # TODO: does anything distinguish "placeholders" from "goals"?
+
+** Opaque Definitions
+
+Because elaboration and unification are so complex, Lean provides
+various mechanism that control the process. To start with, a defined
+symbol can be /transparent/ or /opaque/. This is a very strong,
+irrevocable decision: when a symbol is opaque, its definition
+definition is /never/ unfolded, not even by the type checker in the
+kernel of Lean, whose job it is to determine whether or not a term is
+type correct.
+
+Any identifier created by the =theorem= command is automatically
+marked as opaque, as consistent with the understanding is that all we
+care about is the fact that the theorem is true, which is to say, the
+proposition is asserts, viewed as a type, is inhabited. (If other
+theorems and definitions need to "see" the contents of a proof, you
+must declare it to be a =definition= instead.)
+
+In contrast, an identifier created by the =definition= command is
+marked as transparent, by default. For example, if addition on the
+natural numbers were not transparent, the type checker would reject
+the equation in the check below as a type error:
+#+BEGIN_SRC lean
+import data.vector data.nat
+open nat
+check λ (v : vector nat (2+3)) (w : vector nat 5), v = w
+#+END_SRC
+Similarly, the following definition only type checks because =id= is
+transparent, and the type checker can establish that =nat= and =id
+nat= are definitionally equal.
+#+BEGIN_SRC lean
+import data.nat
+definition id {A : Type} (a : A) : A := a
+check λ (x : nat) (y : id nat), x = y
+#+END_SRC
+
+Lean provides us with an option, however, to declare a definition to
+be opaque as well. Opaque definitions are similar to regular
+definitions, but they are only transparent in the module (file) in
+which they are defined. The idea is that we can prove theorems about
+an opaque constant in the module in which it is defiend, but in other
+modules, we can only rely on these theorems. The actual definition is
+hidden/encapsulated, and the module designer is free to change it
+without affecting its "customers".
+
+Using opaque definitions is subtle. It would be problematic if the
+type checker could determine that the statement of a theorem which
+involves an opaque constant is correct within the module it is
+defined, but not outside the module. For that reason, an opaque
+definition is only treated as transparent inside of other opaque
+definitions/theorems in the same module. Here is an example:
+#+BEGIN_SRC lean
+import data.nat
+opaque definition id {A : Type} (a : A) : A := a
+
+-- these are o.k.
+
+check λ (x : nat) (y : id nat), x = y
+
+theorem id_eq {A : Type} (a : A) : id a = a :=
+eq.refl a
+
+definition id2 {A : Type} (a : A) : A :=
+id a
+
+-- this is rejected
+
+/-
+definition buggy_def {A : Type} (a : A) : Prop :=
+∀ (b : id A), a = b
+-/
+#+END_SRC
+The check command is type correct because it is executed in the same
+module as the =opaque= definition. The proof of =id_eq= is type
+correct, because =id= only needs to be transparent within the
+proof. Similarly, =id2= is type correct because the type checker does
+not need to unfold =id= to ensure correctness. But Lean rejects
+=buggy_def=: the definition would not type check outside the module,
+because that requires unfolding the definition of =id=.
+
+** Reducible Definitions
+
+In addition to being transparent or opaque, identifiers can be
+/reducible/ or /irreducible/. In contrast to declaring an identifier to be
+transparent or opaque, declaring an identifier to be reducible or
+irreducible is nothing more than a hint to help the elaborator solve
+higher-order unification problems. It has no bearing on type checking
+at all, which is to say, once a fully elaborated term is type
+correct, marking one of the constants it contains to be reducible does
+not change the correctness. The type checker in the kernel of Lean
+ignores the annotations. For that reason, the tags are less rigid:
+there is no problem marking a constant reducible at one point, and
+then irreducible later on, or vice-versa.
+
+The purpose of the annotation is to help Lean's unification procedure
+decide which declarations should be unfolded. The higher-order
+unification procedure has to perform case analysis, implementing a
+backtracking search. At various stages, the procedure has to decide
+whether a definition =C= should be unfolded or not.  Here, we roughly
+divide this decision in two groups: /simple/ and /complex/. Let us say
+an unfolding decision is /simple/ if the unfolding does not require
+the procedure to consider an extra case split. It is /complex/ if the
+unfolding produces at least one extra case, and consequently increases
+the search space.
+
+Lean users can mark a definition =reducible= or =irreducible=.  We
+write =reducible(C)= to denote that =C= was marked as reducible by the
+user, and =irreducible(C)= to denote that =C= was marked as
+irreducible by the user. Theorems are never unfolded. For a
+transparent definition =C=, the higher-order unification procedure
+uses the following decision tree.
+#+BEGIN_SRC text
+if simple unfolding decision then
+  if irreducible(C) then
+     do not unfold
+  else
+     unfold
+  end
+else -- complex unfolding decision
+  if reducible(C) then
+     unfold
+  else
+     do not unfold
+  end
+end
+#+END_SRC
+For an opaque definition =D=, the higher-order unification procedure
+uses the same decision tree if =D= was declared in the current
+module. Otherwise, it does not unfold =D=.
+
+To tell the elaborator to consider unfolding a definition when solving
+higher-order unification problems, use the =reducible= annotation:
+#+BEGIN_SRC lean
+definition pr1 [reducible] (A : Type) (a b : A) : A := a
+#+END_SRC
+The annotation is saved with =pr1= in the compiled .olean files. You
+can temporarily alter the annotation with the =reducible= and
+=irreducible= commands. These changes are effective only in the
+current file, and is not saved in the produced .olean file.
+#+BEGIN_SRC lean
+definition id (A : Type) (a : A) : A := a
+definition pr2 (A : Type) (a b : A) : A := b
+
+-- mark pr2 as reducible
+reducible pr2
+
+-- mark id and pr2 as irreducible
+irreducible id pr2
+#+END_SRC
+
+The annotation =[persistent]= can be used to instruct Lean to make the
+modification permanent, and save it in the .olean file.
+#+BEGIN_SRC lean
+definition pr2 (A : Type) (a b : A) : A := b
+
+irreducible [persistent] pr2
+#+END_SRC
+The modification will affect modules that import the one in which the
+persistent declaration occurs. The reducible and irreducible
+annotations can be removed using the modifier =[none]=.
+
+#+BEGIN_SRC lean
+definition pr2 (A : Type) (a b : A) : A := b
+
+-- temporarily remove any reducible and irreducible annotation from pr2
+reducible [none] pr2
+
+-- permanently remove any reducible and irreducible annotation from pr2
+reducible [persistent] [none] pr2
+#+END_SRC
+The command =irreducible= is syntactic sugar for =reducible [off]=.
+The commands =reducible= and =reducible [on]= are equivalent.
 
 ** Helping the Elaborator
 
@@ -795,7 +943,7 @@ end
 
 # TODO: need an example of how [visible] is used.
 
-** Namespaces, Sections, and Contexts
+** More Structuring Commands
 
 Just as =proof ... qed= and =begin ... end= blocks help structure a
 proof, namespaces, sections, and contexts help structure a theory. We
@@ -886,8 +1034,8 @@ check add
 check add.assoc
 check add.comm
 #+END_SRC
-Or, when importing theorems and definitions, you can change the rename
-them at the same time:
+Or, when importing theorems and definitions, you can rename them at
+the same time:
 #+BEGIN_SRC lean
 import data.nat
 open nat (renaming add -> plus)
@@ -944,3 +1092,21 @@ check append
 #+END_SRC
 This makes it possible for you to define nicely prepackaged
 configurations for those who will use your theories later on.
+
+Sometimes it is useful to hide auxiliary definitions and theorems from
+the outside world, for example, so that they do not clutter up the
+namespace. The =private= keyword allows you to do this. A private
+definition is always opaque, and the name of a =private= definition is
+only visible in the module/file where it was declared.
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+private definition inc (x : nat) := x + 1
+private theorem inc_eq_succ (x : nat) : succ x = inc x :=
+  rfl
+#+END_SRC
+In this example, the definition inc and theorem inc_eq_succ are not
+visible or accessible in modules that import this one.
+
+


### PR DESCRIPTION

I revised the discussion of coercions, and incorporated Leo's documentation on declarations and reducibility.

There are still some "TODO"'s in the .org file, but nothing urgent.

The next chapter will be chapter 9, type classes and structures. I am thinking of doing it like this:

o Type classes: start with a simple example, like inhabited. Illustrate that the solution that is found can be context sensitive. Illustrate prolog-like search, e.g. with list and prod. For another example, let's do decidable.

o Structures: insert Leo's tutorial and expand.

o Structures and type classes: more examples

o Controlling class inference: tracing, setting priorities, etc. 