### PR TITLE
routine maintenance

### DIFF
--- a/02_Dependent_Type_Theory.org
+++ b/02_Dependent_Type_Theory.org
@@ -537,6 +537,57 @@ definition curry (A B C : Type) (f : A × B → C) : A → B → C := sorry
 definition uncurry (A B C : Type) (f : A → B → C) : A × B → C := sorry
 #+END_SRC
 
+** Local definitions 
+
+Lean also allows you to introduce "local" definitions using the =let=
+construct. The expression ~let a := t1 in t2~ is definitionally equal to
+the result of replacing every occurrence of =a= in =t1= by =t2=.
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+section
+  variable x : ℕ
+  check let y := x + x in y * y
+end
+
+definition t (x : ℕ) : ℕ :=
+let y := x + x in y * y
+#+END_SRC
+Here, =t= is definitionally equal to the term =(x + x) * (x + x)=.
+You can combine multiple assignments in a single =let= statement:
+#+BEGIN_SRC lean
+import standard 
+open nat
+
+-- BEGIN
+section
+  variable x : ℕ
+  check let y := x + x, z := y + y in z * z
+end
+-- END
+#+END_SRC
+
+Notice that the meaning of the expression ~let a := t1 in t2~ is very
+similar to the meaning of =(λa, t1) t2=, but the two are not the
+same. In the first expression, you should think of every instance of
+=a= in =t2= as a syntactic abbreviation for =t1=. In the second
+expression, =a= is a variable, and the expression =λa, t1= has to make
+sense independent of the value of =a=. The =let= construct is a
+stronger means of abbreviation, and there are expressions of the form
+~let a := t1 in t2~ that cannot be expressed as =(λa, t1) t2=. As an
+exercise, try to understand why the definition of =foo= below type
+checks, but the definition of =bar= does not.
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+definition foo := let a := nat in λx : a, x + 2
+
+/-
+definition bar := (λa, λx : a, x + 2) nat
+-/
+#+END_SRC
 
 ** Namespaces and Sections
 

--- a/02_Dependent_Type_Theory.org
+++ b/02_Dependent_Type_Theory.org
@@ -977,8 +977,8 @@ end hide
 #+END_SRC
 
 All that has changed are the curly braces around =A : Type= in the
-declaration of the constants. We can also use this device in variable
-declarations and function definitions:
+declaration of the constants. We can also use this device in function
+definitions:
 #+BEGIN_SRC lean
 -- the polymorphic identity function
 definition id {A : Type} (x : A) := x
@@ -989,25 +989,30 @@ constants (a : A) (b : B)
 check id
 check id a
 check id b
+#+END_SRC
+This makes the first argument to =id= implicit. Notationally, this
+hides the specification of the type, making it look as though =id=
+simply takes an argument of any type.
 
--- declaring an implicit argument as a section variable
+Implicit arguments can also be declared as section variables:
+#+BEGIN_SRC lean
 section
   variable {A : Type}
   variable x : A
-  definition id2 := x
+  definition id := x
 end
 
-check id2
-check id2 a
-check id2 b
+check id
+check id a
+check id b
 #+END_SRC
+This definition of =id= has the same effect as the one above.
 
-Lean has very complex mechanisms for instantiating such implicit
-arguments, and we will see that they can be used to infer function
-types, predicates, and even proofs. The process of instantiating
- "holes" in a term is often known as /elaboration/. As this tutorial
-progresses, we will gradually learn more of what Lean's powerful
-elaborator can do.
+Lean has very complex mechanisms for instantiating implicit arguments,
+and we will see that they can be used to infer function types,
+predicates, and even proofs. The process of instantiating "holes" in a
+term is often known as /elaboration/. As this tutorial progresses, we
+will gradually learn more of what Lean's powerful elaborator can do.
 
 Sometimes, however, we may find ourselves in a situation where we have
 declared an argument to a function to be implicit, but now want to

--- a/03_Propositions_and_Proofs.org
+++ b/03_Propositions_and_Proofs.org
@@ -427,6 +427,9 @@ section
 end
 -- END
 #+END_SRC
+Because they are so commonly use, the standard library provides the
+abbreviations =and.left= and =and.right= for =and.elim_left= and
+=and.elim_right=, respectively.
 
 Notice that and introduction and and elimination are similar to the
 pairing and projection operations for the cartesian product. The
@@ -601,9 +604,9 @@ section
   example : p ∧ q ↔ q ∧ p :=
   iff.intro
     (assume H : p ∧ q,
-      show q ∧ p, from and.intro (and.elim_right H) (and.elim_left H))
+      show q ∧ p, from and.intro (and.right H) (and.left H))
     (assume H : q ∧ p,
-      show p ∧ q, from and.intro (and.elim_right H) (and.elim_left H))
+      show p ∧ q, from and.intro (and.right H) (and.left H))
 end
 -- END
 #+END_SRC
@@ -622,8 +625,8 @@ section
   variables p q : Prop
 
   example (H : p ∧ q) : q ∧ p :=
-  have Hp : p, from and.elim_left H,
-  have Hq : q, from and.elim_right H,
+  have Hp : p, from and.left H,
+  have Hq : q, from and.right H,
   show q ∧ p, from and.intro Hq Hp
 end
 -- END
@@ -769,8 +772,8 @@ section
   example : p ∧ (q ∨ r) ↔ (p ∧ q) ∨ (p ∧ r) :=
   iff.intro
     (assume H : p ∧ (q ∨ r),
-      have Hp : p, from and.elim_left H,
-      or.elim (and.elim_right H)
+      have Hp : p, from and.left H,
+      or.elim (and.right H)
         (assume Hq : q,
           show (p ∧ q) ∨ (p ∧ r), from or.inl (and.intro Hp Hq))
         (assume Hr : r,
@@ -778,12 +781,12 @@ section
     (assume H : (p ∧ q) ∨ (p ∧ r),
       or.elim H
         (assume Hpq : p ∧ q,
-          have Hp : p, from and.elim_left Hpq,
-          have Hq : q, from and.elim_right Hpq,
+          have Hp : p, from and.left Hpq,
+          have Hq : q, from and.right Hpq,
           show p ∧ (q ∨ r), from and.intro Hp (or.inl Hq))
         (assume Hpr : p ∧ r,
-          have Hp : p, from and.elim_left Hpr,
-          have Hr : r, from and.elim_right Hpr,
+          have Hp : p, from and.left Hpr,
+          have Hr : r, from and.right Hpr,
           show p ∧ (q ∨ r), from and.intro Hp (or.inr Hr)))
 
   -- an example that requires classical reasoning

--- a/05_Interacting_with_Lean.org
+++ b/05_Interacting_with_Lean.org
@@ -611,7 +611,12 @@ eval tt + tt + tt + ff
 print coercions        -- show all coercions
 print coercions bool   -- show all coercions from bool
 #+END_SRC
-We could also declare =bool.to_nat= to be a coercion after the fact as follows:
+The tag "coercion" is an /attribute/ that is associated with the
+symbol =bool.to_nat=. It does not change the meaning of
+=bool.to_nat=. Rather, it associates additional information to the
+symbol that informs Lean's elaboration algorithm, as discussed in
+Section [[Elaboration and Unification]]. We could also declare
+=bool.to_nat= to be a coercion after the fact as follows:
 #+BEGIN_SRC lean
 import data.bool data.nat
 open bool nat
@@ -626,19 +631,6 @@ eval 2 + ff
 eval 2 + tt
 eval tt + tt + tt + ff
 #+END_SRC
-
-Alternatively, you can declare a coercion by using the
-=coercion= modifier when you define the function initially:
-#+BEGIN_SRC lean
-import data.bool data.nat
-open bool nat
-
--- BEGIN
-definition bool.to_nat [coercion] (b : bool) : nat :=
-bool.cond b 1 0
--- END
-#+END_SRC
-
 In both cases, the scope of the coercion is the current namespace, so
 the coercion will be in place whenever the module is imported and the
 namespace is open. Sometimes it is useful to assign an attribute only
@@ -658,10 +650,10 @@ local attribute bool.to_nat [coercion]
 
 For the elaborator to handle coercions effectively, restrictions are
 imposed on the types one can serve as the source and target: roughly,
-they have to be inductively defined types, as described in the next
-chapter. As we will see, most defined datatypes are naturally of this
-form, and in any case it is always possible to "wrap" a definition as
-an inductively defined datatype.
+they have to be inductively defined types, as discussed in Section
+[[More on Coercions]]. As we will see, most defined datatypes are
+naturally of this form, and in any case it is always possible to
+"wrap" a definition as an inductively defined datatype.
 
 Overloads and coercions introduce "choice points" in the elaboration
 process, forcing the elaborator to consider multiple options and

--- a/05_Interacting_with_Lean.org
+++ b/05_Interacting_with_Lean.org
@@ -417,11 +417,22 @@ library and hit "M-.", Emacs will take you to the identifier's
 definition in the library file itself. This works even in an
 autocompletion popup window: if you start typing an identifier, press
 the tab key, choose a completion from the list of options, and press
-"M-.", you are taken to the symbol's definition. These commands and
-others are summarized here:
+"M-.", you are taken to the symbol's definition. When you are done,
+pressing "M-*" takes you back to your original position. 
+
+There are other useful tricks. If you see some notation in a Lean file
+and you want to know how to enter it from the keyboard, put the cursor
+on the symbol and type "C-c C-k". You can set common Lean options with
+"C-c C-o", and you can execute a Lean command using "C-c C-e". These
+commands and others are summarized here:
 #+BEGIN_QUOTE
 [[https://github.com/leanprover/lean/blob/master/src/emacs/README.md][Lean Emacs mode README]]
 #+END_QUOTE
+If for some reason the Lean background process does not seem to be
+responding (for example, the information line no longer shows you type
+information), type "C-c C-r", or "M-x lean-server-restart-process", or
+choose "restart lean process" from the Lean menu, and with luck that
+will set things right again.
 
 This is a good place to mention another trick that is sometimes useful
 when editing long files. In Lean, the "exit" command halts processing

--- a/05_Interacting_with_Lean.org
+++ b/05_Interacting_with_Lean.org
@@ -482,13 +482,18 @@ Incidentally, outside of Emacs, from a terminal window, you can type
 have compiled =.olean= counterparts, and that they are up to date.
 
 ** Notation, Overloads, and Coercions
+:PROPERTIES:
+  :CUSTOM_ID: Notation_Overloads_and_Coercions
+:END:
 
 Lean's parser is an instance of a Pratt parser, a non-backtracking
 parser that is fast and flexible. You can read about Pratt parsers in
 a number of places online, such as here:
 #+BEGIN_QUOTE
+#+ATTR_HTML: target="_blank"
 [[http://en.wikipedia.org/wiki/Pratt_parser][Pratt's parser at Wikipedia]]
 
+#+ATTR_HTML: target="_blank"
 [[http://eli.thegreenplace.net/2010/01/02/top-down-operator-precedence-parsing][Top down operator precedence parsing]]
 #+END_QUOTE
 Identifiers can include any alphanumeric characters, including Greek

--- a/08_Building_Theories_and_Proofs.org
+++ b/08_Building_Theories_and_Proofs.org
@@ -11,15 +11,15 @@ proofs.
 
 In Section [[Notation, Overloads, and Coercions]], we discussed coercions
 briefly, and noted that there are restrictions on the types that one
-can coerce from and to. Now that we have discussed inductive types in
-the Calculus of Constructions, we can be more precise.
+can coerce from and to. Now that we have discussed inductive types, we
+can be more precise.
 
 The most basic type of coercion maps elements of one type to
 another. For example, a coercion from =nat= to =int= allows us to view
 any element =n : nat= as an element of =int=. But some coercions
 depend on parameters; for example, for any type =A=, we can view any
 element =l : list A= as an element of =set A=, namely, the set of
-elements occurring in the list. This corresponding coercion is defined
+elements occurring in the list. The corresponding coercion is defined
 on the "family" of types =list A=, parameterized by =A=.
 
 In fact, Lean allows us to declare three kinds of coercions:
@@ -222,15 +222,15 @@ structure morphism (S1 S2 : Semigroup) : Type :=
 local attribute morphism.mor [coercion]
 -- END
 #+END_SRC
-You can also declare a persistent coercion using the =persistent=
-modifier when you define the function initially, as described in
-Section [[Notation, Overloads, and Coercions]]. Coercions that are defined
-in a namespace "live" in that namespace, and are made active when the
+You can also declare a persistent coercion by assigning the attribute
+when you define the function initially, as described in Section
+[[Notation, Overloads, and Coercions]]. Coercions that are defined in a
+namespace "live" in that namespace, and are made active when the
 namespace is opened.
 
-Remember also that you can
-instruct Lean's pretty-printer to show coercions with =set_option=,
-and you can print all the coercions in the environment using =print coercions=:
+Remember also that you can instruct Lean's pretty-printer to show
+coercions with =set_option=, and you can print all the coercions in
+the environment using =print coercions=:
 #+BEGIN_SRC lean
 structure Semigroup : Type :=
 (carrier : Type)
@@ -371,7 +371,8 @@ The interaction of computation with higher-order unification is
 particularly knotty. For the most part, Lean avoids peforming
 computational reduction when trying to solve higher-order
 constraints. You can override this, however, by marking some symbols
-as =reducible=, as decribed in Section [[Reducible Definitions]].
+with the =reducible= attribute, as decribed in Section [[Reducible
+Definitions]].
 
 The elaborator relies on additional tricks and gadgets to solve a list
 of constraints and instantiate metavariables. Below we will see that
@@ -486,16 +487,17 @@ because that requires unfolding the definition of =id=.
 ** Reducible Definitions
 
 In addition to being transparent or opaque, identifiers can be
-/reducible/ or /irreducible/. In contrast to declaring an identifier to be
-transparent or opaque, declaring an identifier to be reducible or
-irreducible is nothing more than a hint to help the elaborator solve
-higher-order unification problems. It has no bearing on type checking
-at all, which is to say, once a fully elaborated term is type
+/reducible/ or /irreducible/. Whereas being transparent or opaque is a
+fixed, irrevocable feature of an identifier, being reducible or
+irreducible is an attribute that can be altered. This status provides
+hints that govern the way the elaborator tries to solve higher-order
+unification problems. As with other attributes, the status of an
+identifier with respect to reducibility has no bearing on type
+checking at all, which is to say, once a fully elaborated term is type
 correct, marking one of the constants it contains to be reducible does
 not change the correctness. The type checker in the kernel of Lean
-ignores the annotations. For that reason, the tags are less rigid:
-there is no problem marking a constant reducible at one point, and
-then irreducible later on, or vice-versa.
+ignores such attributes, and there is no problem marking a constant
+reducible at one point, and then irreducible later on, or vice-versa.
 
 The purpose of the annotation is to help Lean's unification procedure
 decide which declarations should be unfolded. The higher-order
@@ -508,10 +510,9 @@ the procedure to consider an extra case split. It is /complex/ if the
 unfolding produces at least one extra case, and consequently increases
 the search space.
 
-Lean users can mark a definition =reducible= or =irreducible=.  We
-write =reducible(C)= to denote that =C= was marked as reducible by the
-user, and =irreducible(C)= to denote that =C= was marked as
-irreducible by the user. Theorems are never unfolded. For a
+Let us write =reducible(C)= to denote that =C= has been assigned the
+=reducible= attribute by a user, and =irreducible(C)= to denote that
+=C= has been marked =irreducible=. Theorems are never unfolded. For a
 transparent definition =C=, the higher-order unification procedure
 uses the following decision tree.
 #+BEGIN_SRC text
@@ -533,13 +534,12 @@ For an opaque definition =D=, the higher-order unification procedure
 uses the same decision tree if =D= was declared in the current
 module. Otherwise, it does not unfold =D=.
 
-To tell the elaborator to consider unfolding a definition when solving
-higher-order unification problems, use the =reducible= annotation:
+You can assign the =reducible= attribute when a symbol is defined:
 #+BEGIN_SRC lean
 definition pr1 [reducible] (A : Type) (a b : A) : A := a
 #+END_SRC
-The annotation is saved with =pr1= in the compiled .olean files. You can
-also achieve the same result with the =attribute= command:
+The assignment persists to other modules. You can achieve the same
+result with the =attribute= command:
 
 #+BEGIN_SRC lean
 definition id (A : Type) (a : A) : A := a

--- a/08_Building_Theories_and_Proofs.org
+++ b/08_Building_Theories_and_Proofs.org
@@ -927,37 +927,131 @@ end
 
 # TODO: need an example of how [visible] is used.
 
-** More Structuring Commands
+** Sections and Contexts
 
 Just as =proof ... qed= and =begin ... end= blocks help structure a
-proof, namespaces, sections, and contexts help structure a theory. We
-saw in Section [[Namespaces and Sections]] that the =section= command
-makes it possible not only to group together elements of a theory that
-go together, but also to declare variables that are inserted as
-arguments to theorems and definitions, as necessary.
+proof, Lean provides various sectioning mechanisms that help structure
+a theory. We saw in Section [[Namespaces and Sections]] that the =section=
+command makes it possible not only to group together elements of a
+theory that go together, but also to declare variables that are
+inserted as arguments to theorems and definitions, as necessary. 
+In fact, Lean has two ways of introducing local elements into the
+contexts, namely, as =variables= or as =parameters=. And it has two
+slightly different sectioning notions, namely, =section= and
+=context=. The goal of this section is to explain these variations.
+
+Remember that the =point of the variable command is to declare
+variables for use in theorems, as in the following example:
+#+BEGIN_SRC lean
+import standard
+open nat
+
+section
+  variables x y : ℕ
+
+  definition double := x + x
+
+  check double y
+  check double (2 * x)
+
+  theorem t1 : double x = 2 * x :=
+  calc
+    double x = x + x         : rfl
+         ... = 1 * x + x     : one_mul
+         ... = 1 * x + 1 * x : one_mul
+         ... = (1 + 1) * x   : mul.right_distrib
+         ... = 2 * x         : rfl
+
+  check t1 y
+  check t1 (2 * x)
+
+  theorem t2 : double (2 * x) = 4 * x :=
+  calc
+    double (2 * x) = 2 * (2 * x) : t1
+               ... = 2 * 2 * x   : mul.assoc
+               ... = 4 * x       : rfl
+end
+#+END_SRC
+The definition of =double= does not have to declare =x= as an
+argument; Lean detects the dependence and inserts it
+automatically. Similarly, Lean detects the occurrence of =x= in =t1=
+and =t2=, and inserts it automatically there, too.
+
+Notice that the variable =x= is generalized immediately, so that
+even within the section =double= is a function of =x=, and =t1= and
+=t2= depend explicitly on =x=. This is what makes it possible to apply
+=double= and =t1= to other expressions, like =y= and =2 * x=. It
+corresponds to the ordinary mathematical locution "in this section,
+let =x= and =y= range over the natural numbers." Whenever =x= and =y=
+occur, we assume they denotes natural numbers.
+
+Sometimes, however, we wish to /fix/ a single value in a section. For
+example, in an ordinary mathematical text, we might say "in this
+section, we fix a type, =A=, and a binary relation on =A=." The notion
+of a =parameter= captures this usage:
+#+BEGIN_SRC lean
+import standard
+
+section
+  parameters {A : Type} (R : A → A → Type)
+  hypothesis transR : ∀{x y z}, R x y → R y z → R x z
+
+  variables {a b c d e : A}
+
+  theorem t1 (H1 : R a b) (H2 : R b c) (H3 : R c d) : R a d :=
+  transR (transR H1 H2) H3
+
+  theorem t2 (H1 : R a b) (H2 : R b c) (H3 : R c d) (H4 : R d e) :
+    R a e :=
+  transR H1 (t1 H2 H3 H4)
+
+  check t1
+  check t2
+end
+
+check t1
+check t2
+#+END_SRC
+Here, =hypothesis= functions as a synonym for parameter, so that =A=,
+=R=, and =transR= are all parameters in the section. This means that,
+as before, they are inserted as arguments to definitions and theorems
+as needed. But there is a difference: within the section, =t1= is an
+abbreviation for =@t1 A R transR=, which is to say, these arguments
+are fixed until the section is closed. This means that you do not have
+to specify the explicit arguments =R= and =transR= when you write =t1
+H2 H3 H4=, in constrast to the previous example. But it also means
+that you cannot specify other arguments in their place. In this
+example, making =R= a parameter is appropriate if =R= is the only
+binary relation you want to reason about in the section. If you want
+to apply your theorems to arbitrary binary relations within the
+section, make =R= a variable.
 
 Lean has another sectioning construct, the =context= command, which is
-similar to the =section= command. There are two key differences. The
-first is that, in a context, you can declare /parameters/. A parameter
-declaration is like a variable declaration, except theorems and
-definitions that depend on a parameter are not generalized within the
-=context=, they are only generalized when the context is closed. The
-idea is within the context, the parameter is a single, fixed
-value. For example, if you declare =parameter (x : ℤ)= in a context,
-and then define ~foo := 2 * x~, within the context =foo= is a
-constant, not a function of =x=. The second difference is that
-notations defined in a context are transient: they disappear when the
-context is closed. The reason for this is that a notation that depends
-on a parameter would not make sense outside the context.
+similar to the =section= command. The difference has to do with the
+way that meta-theoretic data is handled. In a =section=, you can
+declare notation, classes, instances, rewrite rules, and so on, and
+they persist when the section is closed. Their scope is the entire
+namespace in which the section resides, and when another module
+imports the once containing the section and opens the relevant
+namespace, all these objects are available. There is a catch: in a
+section, a piece of notation cannot depend on a parameter. After all,
+a notation that is defined with respect to a fixed parameter, like =R=
+above, no longer makes sense when =R= is no longer fixed. As a result,
+in a section, if you try to define notation that depends on a
+parameter, Lean will flag an error.
 
-Contexts are useful when a series of definitions and theorems involves
-a set of parameters that you can think of as being fixed throughout
-the development, and for which it is useful to have temporary
-notation. Here is an example of how you might use a context to define
+In a context, however, all meta-theoretic data is /transient/; it
+disappears when the section is closed. This is useful when you want to
+define notation, rewrite rules, or class instances that are used only
+temporarily and not exported to the outside world. There is therefore
+no problem making notation depend on a parameter in a context; when
+the context is closed, the notation goes with it.
+
+Here is an example of how you might use a context to define
 the notion of equivalence modulo an integer =m=. Throughout the
 context, =m= is fixed, and we can write =a ≡ b= for equivalence modulo
 =m=. As soon as the context is closed, however, the dependence on =m=
-becomes explicit, and the notation is no longer valid.
+becomes explicit, and the notation =a ≡ b= is no longer valid.
 
 #+BEGIN_SRC lean
 import data.int
@@ -996,7 +1090,9 @@ check mod_trans
 # it here and then discuss it more fully, with examples, in the
 # chapter on structures.
 
-Finally, recall from Section [[Namespaces and Sections]] that namespaces
+** More on Namespaces
+
+Recall from Section [[Namespaces and Sections]] that namespaces
 not only package shorter names for theorems and identifiers, but also
 things like notation, coercions, classes, rewrite rules, and so
 on. These can be opened independently using modifiers to the =open=

--- a/08_Building_Theories_and_Proofs.org
+++ b/08_Building_Theories_and_Proofs.org
@@ -9,7 +9,7 @@ proofs.
 
 ** More on Coercions
 
-In Section [[Notation, Overloads, and Coercions]], we discussed coercions
+In Section [[file:05_Interacting_with_Lean::Notation_Overloads_and_Coercions][Notations, Overloads, and Coercions]], we discussed coercions
 briefly, and noted that there are restrictions on the types that one
 can coerce from and to. Now that we have discussed inductive types, we
 can be more precise.

--- a/10_Structures_and_Records.org
+++ b/10_Structures_and_Records.org
@@ -33,24 +33,21 @@ The structure command is essentially a "macro" built on top of the
 inductive datatype provided by the Lean kernel. Every =structure=
 declaration introduces a namespace with the same name. The general
 form of a structure declaration is as follows:
-
 #+BEGIN_SRC text
   structure <name> <parameters> <parent-structures> : Type :=
     <constructor> :: <fields>
 #+END_SRC
-
-Most parts are optional. Here is a small example
-
+Most parts are optional. Here is a small example:
 #+BEGIN_SRC lean
 structure point (A : Type) :=
 mk :: (x : A) (y : A)
 #+END_SRC
 
-Values of type =point= are created using =point.mk a b=, the fields of
-a point =p= are accessed using =point.x p= and =point.y p=. The
-structure command also generates useful recursors and theorems. Here
-are some of the constructions generated for the declaration above.
-
+Values of type =point= are created using =point.mk a b=, and the
+fields of a point =p= are accessed using =point.x p= and =point.y
+p=. The structure command also generates useful recursors and
+theorems. Here are some of the constructions generated for the
+declaration above.
 #+BEGIN_SRC lean
 structure point (A : Type) :=
 mk :: (x : A) (y : A)
@@ -67,7 +64,6 @@ check point.y            -- projection/field accessor
 
 You can obtain the complete list of generated construction using the
 command =print prefix=.
-
 #+BEGIN_SRC lean
 structure point (A : Type) :=
 mk :: (x : A) (y : A)
@@ -78,9 +74,8 @@ print prefix point
 #+END_SRC
 
 Here is some simple theorems and expressions using the generated
-constructions.  As usual, you can avoid the prefix =point= by using
+constructions. As usual, you can avoid the prefix =point= by using
 the command =open point=.
-
 #+BEGIN_SRC lean
 structure point (A : Type) :=
 mk :: (x : A) (y : A)
@@ -100,7 +95,6 @@ rfl
 #+END_SRC
 
 If the constructor is not provided, then a constructor named =mk= is generated.
-
 #+BEGIN_SRC lean
 namespace hide
 -- BEGIN
@@ -113,14 +107,12 @@ end hide
 #+END_SRC
 
 The keyword =record= is an alias for =structure=.
-
 #+BEGIN_SRC lean
 record point (A : Type) :=
 mk :: (x : A) (y : A)
 #+END_SRC
 
 You can provide universe levels explicitly.
-
 #+BEGIN_SRC lean
 namespace hide
 -- BEGIN
@@ -135,9 +127,10 @@ check prod.mk
 end hide
 #+END_SRC
 
-We use =max 1 l= as the resultant universe level to ensure the universe level is never =0=
-even when the parameter =A= and =B= are propositions.
-Recall that in Lean, =Type.{0}= is =Prop= which is impredicative and proof irrelevant.
+We use =max 1 l= as the resultant universe level to ensure the
+universe level is never =0= even when the parameter =A= and =B= are
+propositions.  Recall that in Lean, =Type.{0}= is =Prop=, which is
+impredicative and proof irrelevant.
 
 ** Objects
 
@@ -146,15 +139,12 @@ types. For structures containing many fields, it is quite inconvenient
 to use the constructor to create objects because we have to remember
 the exact order the fields were defined. Therefore, Lean provides
 the following alternative notations for defining objects of structure/record types.
-
 #+BEGIN_SRC text
   {| <structure-type> (, <field-name> := <expr>)* |}
   or
   ⦃ <structure-type> (, <field-name> := <expr>)* ⦄
 #+END_SRC
-
-For an example, let us define objects of the point record.
-
+For example, let us define objects of the point record.
 #+BEGIN_SRC lean
 structure point (A : Type) :=
 mk :: (x : A) (y : A)
@@ -171,7 +161,6 @@ rfl
 Note that =point= is a parametric type, but we did not provide its parameters.
 Lean infers the parameters automatically for us. The parameters can be explicitly
 provided (if needed).
-
 #+BEGIN_SRC lean
 open nat
 structure point (A : Type) :=
@@ -184,7 +173,6 @@ check ⦃ point nat, x := 10, y := 20 ⦄
 If the value of a field is not specified, Lean tries to infer it.
 If the unspecified fields cannot be inferred, Lean signs an error
 indicating the corresponding placeholder could not be synthesized.
-
 #+BEGIN_SRC lean
 structure my_struct :=
 mk :: (A : Type) (B : Type) (a : A) (b : B)
@@ -193,8 +181,7 @@ check {| my_struct, a := 10, b := true |}
 #+END_SRC
 
 The notation for defining record objects can also be used in
-pattern-matching expressions
-
+pattern-matching expressions.
 #+BEGIN_SRC lean
 open nat
 structure big :=
@@ -216,19 +203,16 @@ example : v3 = 3 := rfl
 a new record object by modifying the value of one or more fields.
 Lean provides a variation of the notation described above for
 record updates.
-
 #+BEGIN_SRC text
   {| <structure-type> (, <field-name> := <expr>)* (, <record-obj>)* |}
   or
   ⦃ <structure-type> (, <field-name> := <expr>)* (, <record-obj>)* ⦄
 #+END_SRC
-
-The semantics is quite simple, record objects =<record-obj>=
+The semantics is quite simple: record objects =<record-obj>=
 "provides" the value for unspecified fields. If more than one record
 object is provided, then they are visited in order until Lean finds
 one the contains the unspecified field. Lean signs an error
 if a record object has *not* provided any field.
-
 #+BEGIN_SRC lean
 open nat
 
@@ -250,7 +234,6 @@ rfl
 
 We can /extend/ existing structures by adding new fields.
 This feature allow us to simulate a form of "inheritance".
-
 #+BEGIN_SRC lean
 -- BEGIN
 structure point (A : Type) :=
@@ -267,7 +250,6 @@ mk :: (c : color)
 The type =color_point= inherits all the fields from =point= and
 declares a new one =c : color=.  Lean automatically generates a
 /coercion/ from =color_point= to =point=.
-
 #+BEGIN_SRC lean
 open num
 
@@ -304,7 +286,6 @@ The coercions are named =to_<parent structure>=.
 Lean always declare functions that map the child structure to its parents.
 We can request Lean to *not* mark these functions as coercions by
 using the =private= keyword.
-
 #+BEGIN_SRC lean
 open num
 
@@ -328,7 +309,6 @@ rfl
 #+END_SRC
 
 We can "rename" fields inherited from parent structures using the =renaming= clause.
-
 #+BEGIN_SRC lean
 namespace hide
 -- BEGIN
@@ -353,7 +333,6 @@ end hide
 For another example, we define a structure using "multiple
 inheritance", and then define an object using objects of the parent
 structures.
-
 #+BEGIN_SRC lean
 import data.nat.basic
 open nat


### PR DESCRIPTION

I tried setting a cross-chapter link in Section 8.1. It doesn't work in the PDF file (though the link color changed) and I don't think it worked in the html file either (but we will see what happens when it builds online).

I also tried to add "target=_blank" attributes to the first two links in Section 5.6. I don't think that works either.

I will write the chapter on Type Classes next. I already have an outline and know what to do. I just have to do it.