### PR TITLE
feat(08&09): add information about the (ir)reducible attribute and include/omit

### DIFF
--- a/08_Building_Theories_and_Proofs.org
+++ b/08_Building_Theories_and_Proofs.org
@@ -488,8 +488,8 @@ because that requires unfolding the definition of =id=.
 
 ** Reducible Definitions
 
-In addition to being transparent or opaque, identifiers can be
-/reducible/ or /irreducible/. Whereas being transparent or opaque is a
+Transparent identifiers can be declared to be /reducible/ or /irreducible/ or /none/.
+By default, a definition is none. Whereas being transparent or opaque is a
 fixed, irrevocable feature of an identifier, being reducible or
 irreducible is an attribute that can be altered. This status provides
 hints that govern the way the elaborator tries to solve higher-order
@@ -505,36 +505,21 @@ The purpose of the annotation is to help Lean's unification procedure
 decide which declarations should be unfolded. The higher-order
 unification procedure has to perform case analysis, implementing a
 backtracking search. At various stages, the procedure has to decide
-whether a definition =C= should be unfolded or not.  Here, we roughly
-divide this decision in two groups: /simple/ and /complex/. Let us say
-an unfolding decision is /simple/ if the unfolding does not require
-the procedure to consider an extra case split. It is /complex/ if the
-unfolding produces at least one extra case, and consequently increases
-the search space.
+whether a definition =C= should be unfolded or not.
++ An /irreducible/ definition will never be unfolded during higher-order unification
+  (but can still be unfolded in other situations, for example during type checking)
++ A /reducible/ definition will be always eligible for unfolding
++ A definition which is /none/ can be unfolded during /simple/ decisions
+  and won't be unfolded during /complex/ decisions.
+  An unfolding decision is /simple/ if the unfolding does not require
+  the procedure to consider an extra case split. It is /complex/ if the
+  unfolding produces at least one extra case, and consequently increases
+  the search space.
 
-Let us write =reducible(C)= to denote that =C= has been assigned the
-=reducible= attribute by a user, and =irreducible(C)= to denote that
-=C= has been marked =irreducible=. Theorems are never unfolded. For a
-transparent definition =C=, the higher-order unification procedure
-uses the following decision tree.
-#+BEGIN_SRC text
-if simple unfolding decision then
-  if irreducible(C) then
-     do not unfold
-  else
-     unfold
-  end
-else -- complex unfolding decision
-  if reducible(C) then
-     unfold
-  else
-     do not unfold
-  end
-end
-#+END_SRC
-For an opaque definition =D=, the higher-order unification procedure
-uses the same decision tree if =D= was declared in the current
-module. Otherwise, it does not unfold =D=.
+Identifiers which are opaque (theorems and opaque definitions declared
+in a different module) will never be unfolded. Opaque definitions declared
+in the current module can be marked to be reducible and irreducible as normal,
+since they are transparent in the current module.
 
 You can assign the =reducible= attribute when a symbol is defined:
 #+BEGIN_SRC lean
@@ -564,6 +549,8 @@ definition pr2 (A : Type) (a b : A) : A := b
 local attribute pr2 [irreducible]
 #+END_SRC
 
+# TODO: add command to remove reducible/irreducible attribute (i.e. go back to "none")
+
 ** Helping the Elaborator
 
 Because proof terms and expressions in dependent type theory can
@@ -579,12 +566,15 @@ information. This section provides some guidance in both situations.
 
 If the error message is not sufficient to allow you to identify the
 problem, a first strategy is to ask Lean's pretty printer to show more
-information, as discussed in Section [[Setting Options]]:
+information, as discussed in Section [[Setting Options]],
+using some or all of the following options:
 #+BEGIN_SRC lean
 set_option pp.implicit true
 set_option pp.universes true
 set_option pp.notation false
+set_option pp.coercions true
 set_option pp.numerals false
+set_option pp.full_names true
 #+END_SRC
 Sometimes, the elaborator will fail with the message that the unifier
 has exceeded its maximum number of steps. As we noted in the last
@@ -668,7 +658,7 @@ long terms internal to a proof using auxiliary =have= statements can
 help locate the source of an error.
 
 The second strategy, providing additional information, can be achieved
-by using =have=, =show=, and the =typeof= construct (see Section
+by using =have=, =show=, =typeof= and =#<namespace>= (see Section
 [[Notation, Overloads, and Coercions]]) to indicate expected types. More
 directly, it often help to specify the implicit arguments. When Lean
 cannot solve for the value of a metavariable corresponding to an
@@ -689,7 +679,7 @@ contexts, namely, as =variables= or as =parameters=. And it has two
 slightly different sectioning notions, namely, =section= and
 =context=. The goal of this section is to explain these variations.
 
-Remember that the =point of the variable command is to declare
+Remember that the point of the variable command is to declare
 variables for use in theorems, as in the following example:
 #+BEGIN_SRC lean
 import standard
@@ -725,6 +715,10 @@ The definition of =double= does not have to declare =x= as an
 argument; Lean detects the dependence and inserts it
 automatically. Similarly, Lean detects the occurrence of =x= in =t1=
 and =t2=, and inserts it automatically there, too.
+Note that double does /not/ have =y= as argument. Variables are only
+included in declarations where they are actually mentioned.
+To force that a variable is included in every definition in a section, use
+the =include= command. This is useful for type classes, see next chapter.
 
 Notice that the variable =x= is generalized immediately, so that
 even within the section =double= is a function of =x=, and =t1= and
@@ -846,10 +840,6 @@ check mod_refl
 check mod_sym
 check mod_trans
 #+END_SRC
-
-# TODO: somewhere, we need to describe include / omit. Maybe mention
-# it here and then discuss it more fully, with examples, in the
-# chapter on structures.
 
 ** More on Namespaces
 

--- a/09_Type_Classes.org
+++ b/09_Type_Classes.org
@@ -754,18 +754,78 @@ trace of the search:
 #+BEGIN_SRC lean
 set_option class.trace_instances true
 #+END_SRC
-You can also limit the search depth:
+You can also limit the search depth (the default is 32):
 #+BEGIN_SRC lean
 set_option class.instance_max_depth 5
 #+END_SRC
 Remember also that in the Emacs Lean mode, tab completion works in
 =set_option=, to help you find suitable options.
 
-# As noted above, the type class instances in a given context represent
-# a prolog-like program, which gives rise to a backtracking search. Both
-# the efficiency of the program and the solutions that are found can
-# depend on the order in which the system tries the instance.
-# ... Can users control this?
+As noted above, the type class instances in a given context represent
+a prolog-like program, which gives rise to a backtracking search. Both
+the efficiency of the program and the solutions that are found can
+depend on the order in which the system tries the instance.
+Instances which are declared last are tried first.
+Moreover, if instances are declared in other modules, the order in which
+they are tried depends on the order in which namespaces are opened.
+Instances declared in namespaces which are opened later are tried earlier.
+
+** Instances in Sections
+
+We can easily assume instances of type classes in a complete section
+using variables (or in a context using parameters). Recall
+that variables are only included in declarations when they are actually
+mentioned. Instances of type classes are rarely explicitly mentioned in
+definitions, so to make sure that an instance of a type class is included
+in definitions, we use the =include= command.
+#+BEGIN_SRC lean
+import standard
+
+inductive has_add [class] (A : Type) : Type :=
+mk : (A → A → A) → has_add A
+
+definition add {A : Type} [s : has_add A] :=
+has_add.rec (λx, x) s
+
+notation a `+` b := add a b
+
+-- BEGIN
+section
+  variables {A : Type} [H : has_add A] (a b : A)
+  include H
+
+  definition foo : a + b = a + b := rfl
+  check @foo
+end
+-- END
+#+END_SRC
+Note that the =include= command includes a variable in every definition in that section.
+If we want to declare some definitions which do not use the instance, we can use the =omit= command:
+#+BEGIN_SRC lean
+inductive has_add [class] (A : Type) : Type :=
+mk : (A → A → A) → has_add A
+
+definition add {A : Type} [s : has_add A] :=
+has_add.rec (λx, x) s
+
+notation a `+` b := add a b
+
+-- BEGIN
+section
+  variables {A : Type} [H : has_add A] (a b : A)
+  include H
+  definition foo1 : a + b = a + b := rfl
+  omit H
+  definition foo2 : a  = a := rfl -- H is not an argument of foo2
+  include H
+  definition foo3 : a + a = a + a := rfl
+
+  check @foo1
+  check @foo2
+  check @foo3
+end
+-- END
+#+END_SRC
 
 ** Bounded quantification
 


### PR DESCRIPTION
* I rewrote parts of the section about the (ir)reducible attribute to make it clearer that a declaration can also be neither `reducible` nor `irreducible`. Maybe we need a better name for this than `none`. I removed the pseudocode in favor of a description what the attributes do. 
* We might want to be more explicit where the (ir)reducible attributes are used. It's not only used for higher-order unification, but also for class inference, and perhaps more, but I wasn't certain about this.
* I remember that there is some way to remove the (ir)reducible attribute from an identifier, but I forgot how, that still needs to be added. 
* I also added a description of the `include`/`omit` command. I think the chapter on type classes is better for this than the chapter on structures, because it is useful for instances of any type class. I also mentioned `include` in chapter 8 section "Sections and Contexts"
* I couldn't build the files (I didn't want to download a couple hunderd MB of LaTeX packages on the wifi where I'm now), so please review whether it looks good.
* Feel free to change/revert/adjust anything. In particular, the examples of `include`/`omit` are a bit trivial.