### PR TITLE
computational behavior in axioms chapter, and extensions to proof language

### DIFF
--- a/03_Propositions_and_Proofs.org
+++ b/03_Propositions_and_Proofs.org
@@ -625,7 +625,7 @@ check and_swap p q    -- p ∧ q ↔ q ∧ p
 -- END
 #+END_SRC
 Because they represent a form of /modus ponens/, =iff.elim_left= and
-=iff.elim_right= can be abbreviated =iff.mp= and =iff.mp'=,
+=iff.elim_right= can be abbreviated =iff.mp= and =iff.mpr=,
 respectively.  In the next example, we use that theorem to derive =q ∧
 p= from =p ∧ q=:
 #+BEGIN_SRC lean
@@ -771,7 +771,7 @@ such reasoning freely, without any extra justification.
 
 There are additional classical axioms that are not included by default
 in the standard library. We will discuss these in detail in Chapter
-[[file:10_Axioms.org::#Axioms][Axioms]].
+[[file:10_Axioms.org::#Axioms_and_Computation][Axioms and Computation].
 
 ** Examples of Propositional Validities
 :PROPERTIES:

--- a/04_Quantifiers_and_Equality.org
+++ b/04_Quantifiers_and_Equality.org
@@ -641,3 +641,178 @@ iff.intro
               show false, from Hnap Hap)))
 -- END
 #+END_SRC
+
+** More on the Proof Language
+
+We have seen that keywords like =assume=, =take=, =have=, =show=, and
+=obtain= make it possible to write formal proof terms that mirror the
+structure of informal mathematical proofs. In this section, we discuss
+some additional features of the proof language that are often
+convenient.
+
+To start with, we can use anonymous "have" expressions to introduce an
+auxiliary goal without having to label it. We can refer to the last
+expression introduced in this way using the keyword =this=:
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+variable f : ℕ → ℕ
+premise H : ∀ x : ℕ, f x ≤ f (x + 1)
+
+example : f 0 ≤ f 3 :=
+have f 0 ≤ f 1, from H 0,
+have f 0 ≤ f 2, from le.trans this (H 1),
+show f 0 ≤ f 3, from le.trans this (H 2)
+#+END_SRC
+Often proofs move from one fact to the next, so this can be effective
+in eliminating the clutter of lots of labels. 
+
+One can also refer to any element or hypothesis in the context,
+anonymous or not, by enclosing the type in backticks:
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+variable f : ℕ → ℕ
+premise H : ∀ x : ℕ, f x ≤ f (x + 1)
+
+-- BEGIN
+example : f 0 ≤ f 3 :=
+have f 0 ≤ f 1, from H 0,
+have f 0 ≤ f 2, from le.trans `f 0 ≤ f 1` (H 1),
+show f 0 ≤ f 3, from le.trans `f 0 ≤ f 2` (H 2)
+-- END
+#+END_SRC
+In the last line, for example, the expression =`f 0 ≤ f 2`= means "find
+any element of the context that has type =f 0 ≤ f 2=." In other words,
+we state the assertion rather than name the variable that witnesses
+its truth. This can be done anywhere later in the proof:
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+variable f : ℕ → ℕ
+premise H : ∀ x : ℕ, f x ≤ f (x + 1)
+
+-- BEGIN
+example : f 0 ≤ f 3 :=
+have f 0 ≤ f 1, from H 0,
+have f 1 ≤ f 2, from H 1,
+have f 2 ≤ f 3, from H 2,
+show f 0 ≤ f 3, from le.trans `f 0 ≤ f 1` (le.trans `f 1 ≤ f 2` `f 2 ≤ f 3`)
+-- END
+#+END_SRC
+
+The =suppose= keyword acts as an anonymous assume:
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+variable f : ℕ → ℕ
+premise H : ∀ x : ℕ, f x ≤ f (x + 1)
+
+-- BEGIN
+example : f 0 ≥ f 1 → f 0 = f 1 :=
+suppose f 0 ≥ f 1,
+show f 0 = f 1, from le.antisymm (H 0) this
+--END
+#+END_SRC
+Using the keyword =assume= for this purpose would result in a
+syntactic ambiguity, since the expression =assume h k= could mean
+"assume =h= and assume =k=", leaving Lean to infer the relevant
+hypotheses from the context, or "assume proposition =h k= without a
+label". Using =suppose= avoids the problem. As with the anonymous
+=have=, the assumption can also be invoked by enclosing the assertion
+in backticks later in the proof.
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+variable f : ℕ → ℕ
+premise H : ∀ x : ℕ, f x ≤ f (x + 1)
+
+-- BEGIN
+example : f 0 ≥ f 1 → f 1 ≥ f 2 → f 0 = f 2 :=
+suppose f 0 ≥ f 1,
+suppose f 1 ≥ f 2,
+have f 0 ≥ f 2, from le.trans `f 2 ≤ f 1` `f 1 ≤ f 0`,
+have f 0 ≤ f 2, from le.trans (H 0) (H 1),
+show f 0 = f 2, from le.antisymm this `f 0 ≥ f 2`
+-- END
+#+END_SRC
+Notice that =le.antisymm= is the assertion that if =a ≤ b= and =b ≤ a=
+then =a = b=, and =a ≥ b= is definitionally equal to =b ≤ a=.
+
+One can also do an anonymous =assume= by enclosing the statement in
+backticks. 
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+variable f : ℕ → ℕ
+premise H : ∀ x : ℕ, f x ≤ f (x + 1)
+
+-- BEGIN
+example : f 0 ≥ f 1 → f 1 ≥ f 2 → f 0 = f 2 :=
+assume `f 0 ≥ f 1`,
+assume `f 1 ≥ f 2`,
+have f 0 ≥ f 2, from le.trans `f 2 ≤ f 1` `f 1 ≤ f 0`,
+have f 0 ≤ f 2, from le.trans (H 0) (H 1),
+show f 0 = f 2, from le.antisymm this `f 0 ≥ f 2`
+-- END
+#+END_SRC
+This is slightly weaker than using =suppose=, because we can no longer
+use the identifier =this=. But the mechanism is more general: it can
+be used with other binders, like =take= and =obtains=. 
+
+If more than one element of the context has the named type, the
+expression is ambiguous: 
+#+BEGIN_SRC lean
+definition imp_self (p : Prop) : p → p :=
+assume `p`, `p`
+
+print imp_self
+
+definition imp_self2 (p : Prop) : p → p → p :=
+assume `p` `p`, `p`
+
+print imp_self2
+#+END_SRC
+The output shows that in the second example, it is the second argument
+that is chosen. Using anonymous binders when data is involved looks
+somewhat odd:
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+-- BEGIN
+definition idnat : ℕ → ℕ :=
+take `ℕ`, `ℕ`
+
+print idnat
+
+definition idnat2 : ℕ → ℕ → ℕ :=
+take `ℕ` `ℕ`, `ℕ`
+
+print idnat2
+eval idnat2 0 1  -- returns 1
+-- END
+#+END_SRC
+But with propositions it is usually quite natural. Here is an example
+of an anonymous binder used with the =obtain= construction, continuing
+the examples above.
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+-- BEGIN
+variable f : ℕ → ℕ
+premise H : ∀ x : ℕ, f x ≤ f (x + 1)
+
+example (H' : ∃ x, f (x + 1) ≤ f x) : ∃ x, f (x + 1) = f x :=
+obtain x `f (x + 1) ≤ f x`, from H',
+exists.intro x
+  (show f (x + 1) = f x, from le.antisymm `f (x + 1) ≤ f x` (H x))
+-- END
+#+END_SRC

--- a/08_Building_Theories_and_Proofs.org
+++ b/08_Building_Theories_and_Proofs.org
@@ -1020,7 +1020,7 @@ section mod_m
   show m ∣ a - a, from (sub_self a)⁻¹ ▸ !dvd_zero
 
   theorem mod_symm (H : a ≡ b) : b ≡ a :=
-  have H1 : (m ∣ -(b - a)), from iff.mp' !dvd_neg_iff_dvd H,
+  have H1 : (m ∣ -(b - a)), from iff.mpr !dvd_neg_iff_dvd H,
   int.neg_sub b a ▸ H1
 
   theorem mod_trans (H1 : a ≡ b) (H2 : b ≡ c) : a ≡ c :=

--- a/12_Axioms.org
+++ b/12_Axioms.org
@@ -1,9 +1,9 @@
 #+Title: Theorem Proving in Lean
 #+Author: [[http://www.andrew.cmu.edu/user/avigad][Jeremy Avigad]], [[http://leodemoura.github.io][Leonardo de Moura]]
 
-* Axioms
+* Axioms and Computation
 :PROPERTIES:
-  :CUSTOM_ID: Axioms
+  :CUSTOM_ID: Axioms_and_Computation
 :END:
 
 We have seen that the version of the Calculus of Inductive
@@ -16,23 +16,37 @@ convenient; it can make it possible to prove more theorems, as well as
 make it easier to prove theorems that could have been proved
 otherwise. But there can negative consequences of adding additional
 axioms, consequences which may go beyond concerns about their
-correctness.
+correctness. In particular, the use of axioms bears on the
+computational content of definitions and theorems, in ways we will
+explore here.
 
-Lean's standard library makes available a number of "classical"
-axioms, which are justified on a set-theoretic interpretation of type
-theory. These axioms are at odds with a constructive interpretation of
-the system, as well as its computational behavior. When you import the
-standard library, most of these axioms are therefore not imported by
-default.
+Lean is designed to support both computational and classical
+reasoning. Users that are so inclined can stick to a "computationally
+pure" fragment, which guarantees that closed expressions in the system
+evaluate to canonical normal forms. In particular, any closed
+computationally pure expression of type =ℕ=  for example, any closed expression
+denoting a natural number will reduce to a numeral. 
 
-The standard library does, however, make use of two mildly classical
-extensions, namely, propositional extensionality and quotients. Their use
-in core parts of the standard library is still provisional, and may be
-curtailed if it proves to have sufficiently bad computational
-effects. The next section aims to clarify some of the issues and
-concerns.
+To support classical reasoning, Lean's standard library defines a
+number of "classical" axioms, which are justified on a set-theoretic
+interpretation of type theory. The library imports two mildly
+classical axioms, propositional extensionality and quotients. These
+are used, for example, to develop a theories of sets and finite sets.
+Even some computationally inclined users may also wish to use the law
+of the excluded middle to reason about computation. Below we will
+describe the effects that these axioms have on computation aspects of
+the system.
 
-** Computation and Axioms
+There is one classical construction, however, that is entirely
+inimical to a computational interpretation of the system, namely, the
+Hilbert operator, which magically produces "data" from a proposition
+asserting its existence. Its use is essential to some classical
+constructions, and users can import it when needed. But expressions
+that depend on this construction lose their computational content, and
+in Lean we are required to mark such definitions as =noncomputable= to
+flag that fact. 
+
+** Historical and Philosophical Context
 
 For most of its history, mathematics was essentially computational:
 geometry dealt with constructions of geometric objects, algebra was
@@ -84,16 +98,22 @@ elements can help us reason about the effects of the computation, but
 can be ignored when we extract "code" from the term. Elements of type
 =Prop= are not entirely innocuous, however. They include equations =s
 = t : A= for any type =A=, and such equations can be used as casts, to
-type check terms.
+type check terms. Below, we will see examples of how such casts can
+block computation in the system. However, computation is still
+possible under an evaluation scheme that erases propositional content,
+ignore intermediate typing constraints, and reduces terms until they
+reach a normal form. Current plans for Lean include the development of
+a fast evaluator along these lines.
 
 Having adopted a proof-irrelevant =Prop=, one might consider it
 legitimate to add arbitrary classical axioms, such as the law of the
-excluded middle, governing propositions. From a constructive point of
-view, the most objectionable classical axioms are "choice axioms" that
-allow us to extract "data" from any existential proposition,
-completely erasing the distinction between the proof-irrelevant and
-data-relevant parts of the theory. These are discussed in Section
-[[#Choice_Axioms][Choice Axioms]] below.
+excluded middle, governing propositions. Of course, this, too, can
+block computation, but it does not block fast evaluation as described
+above.  From a constructive point of view, the most objectionable
+classical axioms are "choice axioms" that allow us to extract "data"
+from any existential proposition, completely erasing the distinction
+between the proof-irrelevant and data-relevant parts of the
+theory. These are discussed in Section [[#Choice_Axioms][Choice Axioms]] below.
 
 ** Propositional Extensionality
 
@@ -240,10 +260,50 @@ end set
 end hide
 #+END_SRC
 
-
 In fact, function extensionality follows from the existence of
 quotients, which we describe in the next section. In the Lean standard
-library, therefore, =funext= is thus [[https://github.com/leanprover/lean/blob/master/library/init/funext.lean][proved from the quotient construction]].
+library, therefore, =funext= is thus [[https://github.com/leanprover/lean/blob/master/library/init/funext.lean][proved from the quotient
+construction]].
+
+The following is an example of how function extensionality blocks
+computation. 
+#+BEGIN_SRC lean
+import data.nat
+open nat
+
+definition f₁ (x : ℕ) := x
+definition f₂ (x : ℕ) := 0 + x
+
+theorem feq : f₁ = f₂ := funext (take x, eq.subst !zero_add rfl)
+check eq.rec (0 : ℕ) feq    -- ℕ
+eval eq.rec (0 : ℕ) feq     -- eq.rec 0 feq
+#+END_SRC
+First, we show that the two functions =f₁= and =f₂= are equal using
+function extensionality, and then we "cast" =0= of type =ℕ= by
+replacing =f₁= by =f₂= in the type. Of course, the cast is vacuous,
+because =ℕ= does not depend on =f₁=. But that is enough to do the
+damage: under the computational rules of the system, we now have a
+closed term of =ℕ= that does not reduce to a numeral. In this case, we
+may be tempted to "reduce" the expression to =0=. But in nontrivial
+examples, eliminating cast changes the type of the term, which might
+make an ambient expression type incorrect. 
+
+In the next section, we will exhibit a similar example with the
+quotient construction.  Current research programs, including work on
+/observational type theory/ and /cubical type theory/ aim to extend
+type theory in ways that permit reductions for casts involving
+function extensionality, quotients, and more. But the solutions are
+not so clear cut, and the rules of Lean's underlying calculus to not
+sanction such reductions.
+
+In a sense, however, a cast does not change the "meaning" of an
+expression. Rather, it is a mechanism to reason about the expression's
+type. Given an appropriate semantics, it then makes sense to reduce
+terms in ways that preserve their meaning, ignoring the intermediate
+bookkeeping needed to make the reductions type correct. In that case,
+adding new axioms in =Prop= does not matter; by proof irrelevance, an
+expression in =Prop= carries no information, and can be safely ignored
+by the reduction procedures.
 
 ** Quotients
 
@@ -598,6 +658,22 @@ namespace uprod
 end uprod
 #+END_SRC
 
+The quotient construction can be used to derive function
+extensionality, and we have seen that the latter blocks
+computation. The following provides another example of the same
+phenomenon, similar to the one we discussed in the last section. 
+#+BEGIN_SRC lean
+import data.finset
+open finset quot list nat
+
+definition s₁ : finset nat := to_finset [1, 2]
+definition s₂ : finset nat := to_finset [2, 1]
+
+theorem seq : s₁ = s₂ := dec_trivial
+check eq.rec (0 : ℕ) seq
+eval eq.rec (0 : ℕ) seq
+#+END_SRC
+
 ** Excluded Middle
 
 The law of the excluded middle is the following:
@@ -675,7 +751,7 @@ the classical axioms. Separating the =x= asserted to exist by the
 axiom from the property it satisfies allows us to define the Hilbert
 epsilon function:
 #+BEGIN_SRC lean
-import data.subtype
+import logic.quantifiers data.subtype
 open subtype nonempty
 
 namespace hide
@@ -684,7 +760,7 @@ axiom strong_indefinite_description {A : Type} (P : A → Prop) (H : nonempty A)
   { x | (∃ y : A, P y) → P x}
 
 -- BEGIN
-definition epsilon {A : Type} [H : nonempty A] (P : A → Prop) : A :=
+noncomputable definition epsilon {A : Type} [H : nonempty A] (P : A → Prop) : A :=
 let u : {x | (∃ y, P y) → P x} :=
   strong_indefinite_description P H in
 elt_of u
@@ -704,7 +780,10 @@ end hide
 #+END_SRC
 Assuming the type =A= is nonempty, =epsilon P= returns an element of
 =A=, with the property that if any element of =A= satisfies =P=,
-=epsilon P= does.
+=epsilon P= does. Notice that the definition is preceded by the
+keyword =noncomputable=, to signal the fact that expressions depending
+on this definition will not compute to canonical normal forms, even
+under the more liberal evaluation scheme described above.
 
 Just as =indefinite_description= is a weaker version of
 =strong_indefinite_description=, the =some= operator is a weaker
@@ -712,7 +791,7 @@ version of the =epsilon= operator. It is sometimes easier to
 use. Assuming =H : ∃ x, P x= is a proof that some element of =A=
 satisfies =P=, =some H= denotes such an element.
 #+BEGIN_SRC lean
-import data.subtype
+import logic.quantifiers data.subtype
 open subtype nonempty
 
 namespace hide
@@ -720,7 +799,7 @@ namespace hide
 axiom strong_indefinite_description {A : Type} (P : A → Prop) (H : nonempty A) :
   { x | (∃ y : A, P y) → P x}
 
-definition epsilon {A : Type} [H : nonempty A] (P : A → Prop) : A :=
+noncomputable definition epsilon {A : Type} [H : nonempty A] (P : A → Prop) : A :=
 let u : {x | (∃ y, P y) → P x} :=
   strong_indefinite_description P H in
 elt_of u
@@ -736,7 +815,7 @@ theorem epsilon_spec {A : Type} {P : A → Prop} (Hex : ∃ y, P y) :
 epsilon_spec_aux (nonempty_of_exists Hex) P Hex
 
 -- BEGIN
-definition some {A : Type} {P : A → Prop} (H : ∃ x, P x) : A :=
+noncomputable definition some {A : Type} {P : A → Prop} (H : ∃ x, P x) : A :=
 @epsilon A (nonempty_of_exists H) P
 
 theorem some_spec {A : Type} {P : A → Prop} (H : ∃ x, P x) : P (some H) :=
@@ -841,10 +920,10 @@ way to implement such a function in general, the construction is not
 informative.
 
 #+BEGIN_SRC lean
-import algebra.function logic.axioms.classical
+import logic.axioms.classical
 open function
 
-definition linv {A B : Type} [h : inhabited A] (f : A → B) : B → A :=
+noncomputable definition linv {A B : Type} [h : inhabited A] (f : A → B) : B → A :=
 λ b : B, if ex : (∃ a : A, f a = b) then some ex else arbitrary A
 
 theorem has_left_inverse_of_injective {A B : Type} {f : A → B}
@@ -901,8 +980,8 @@ definition U (x : Prop) : Prop := x = true ∨ p
 definition V (x : Prop) : Prop := x = false ∨ p
 
 -- BEGIN
-definition u := epsilon U
-definition v := epsilon V
+noncomputable definition u := epsilon U
+noncomputable definition v := epsilon V
 
 lemma u_def : U u :=
 epsilon_spec (exists.intro true (or.inl rfl))
@@ -926,8 +1005,8 @@ parameter  p : Prop
 definition U (x : Prop) : Prop := x = true ∨ p
 definition V (x : Prop) : Prop := x = false ∨ p
 
-definition u := epsilon U
-definition v := epsilon V
+noncomputable definition u := epsilon U
+noncomputable definition v := epsilon V
 
 lemma u_def : U u :=
 epsilon_spec (exists.intro true (or.inl rfl))
@@ -962,8 +1041,8 @@ parameter  p : Prop
 definition U (x : Prop) : Prop := x = true ∨ p
 definition V (x : Prop) : Prop := x = false ∨ p
 
-definition u := epsilon U
-definition v := epsilon V
+noncomputable definition u := epsilon U
+noncomputable definition v := epsilon V
 
 lemma u_def : U u :=
 epsilon_spec (exists.intro true (or.inl rfl))
@@ -1009,8 +1088,8 @@ parameter  p : Prop
 definition U (x : Prop) : Prop := x = true ∨ p
 definition V (x : Prop) : Prop := x = false ∨ p
 
-definition u := epsilon U
-definition v := epsilon V
+noncomputable definition u := epsilon U
+noncomputable definition v := epsilon V
 
 lemma u_def : U u :=
 epsilon_spec (exists.intro true (or.inl rfl))
@@ -1052,12 +1131,11 @@ or.elim not_uv_or_p
 end
 #+END_SRC
 
-
-
 ** Constructive Choice
 
-In the standard library, we say a type =A= is =encodable= if there are functions =f : A → nat= and =g : nat → option A=
-such that for all =a : A=, =g (f a) = some a=. Here is the actual definition:
+In the standard library, we say a type =A= is =encodable= if there are
+functions =f : A → nat= and =g : nat → option A= such that for all
+=a : A=, =g (f a) = some a=. Here is the precise definition:
 
 #+BEGIN_SRC lean
 namespace hide
@@ -1102,7 +1180,7 @@ long as we can decide whether =b= is in the image of a function =f : A
 → B=.
 
 #+BEGIN_SRC lean
-import data.encodable algebra.function
+import data.encodable
 open encodable function
 
 section
@@ -1140,7 +1218,7 @@ many types have decidable equality.  The hypothesis =dex= can be
 satisfied in many cases. For example, it is trivially satisfied if =f=
 is surjective. It is also satisfied whenever =A= is finite.
 #+BEGIN_SRC lean
-import data.encodable algebra.function
+import data.encodable
 open encodable function
 
 -- BEGIN

--- a/A1_Quick_Reference.org
+++ b/A1_Quick_Reference.org
@@ -1,16 +1,6 @@
 #+Title: Lean Quick Reference
 #+Author: [[http://www.andrew.cmu.edu/user/avigad][Jeremy Avigad]], [[http://leodemoura.github.io][Leonardo de Moura]], [[http://www.cs.cmu.edu/~soonhok][Soonho Kong]]
 #+DATE: \href{https://github.com/leanprover/tutorial/commit/\gitHash}{Version \gitAbbrevHash}, updated at \gitAuthorIsoDate
-# Note: the PDF version and the Github org can fit about 100 characters on a line. To be safe,
-# here, we break at 95
-
-# TODO: should we rename xrewrite to erewrite? JA: I vote "yes"
-# TODO: better name for unfold_c: JA: how about rec-arg? 
-# TODO: the 'e' prefix in eapply is misleading since we usually use it for the "expensive" 
-#       version, what about 'rapply'; JA: o.k. with me
-# TODO: should "rexact" be called 'eexact', for expensive-exact? JA : o.k. with me.
-# TODO: in esimp, 'e' is supposed to mean "evaluator" :-(, I wanted to use 'simp' for the 
-#       simplifier); JA : I think that is o.k.
 
 * Quick Reference
 
@@ -86,6 +76,16 @@ show            : make result type explicit
 match ... with  : introduce proof or definition by cases
 proof ... qed   : introduce a proof or definition block, elaborated separately
 #+END_SRC
+
+The keywords =have= and =assert= can be anonymous, which is to say, they can be used without
+giving a label to the hypothesis. The corresponding element of the context can then be
+referred to using the keyword =this= until another anonymous element is introduced, or by
+enclosing the assertion in backticks. To avoid a syntactic ambiguity, the keyword =suppose= 
+is used instead of =assume= to introduce an anonymous assumption.
+
+One can also use anonymous binders (like =lambda=, =take=, =obtain=, etc.) by enclosing
+the type in backticks, as in =λ `nat`, `nat` + 1=. This introduces a variable of the given
+type in the context with a hidden name.
 
 *** Tactic Mode
 


### PR DESCRIPTION

@leodemoura Please take a look at the revised "Axioms" chapter (now "Axioms and Computation") and make sure you are happy with the story.

@soonhokong In addition to the new features you just implemented for emacs mode, if you think of other features or options that should be discussed, please let me know. There is a brief list in the quick reference.

I plan to write three more chapters for the tutorial: equality and dependent types, more tactics, and HoTT. Of the three, it seems to me that the "more tactics" chapter is the most important. I will try to write that before the tutorial, at least a "work in progress" version. We are now using the tactics a lot, and some important tactics, like the induction tactic, are not yet discussed in the tutorial.