### PR TITLE
fix(03): remove duplicate exercise

### DIFF
--- a/03_Propositions_and_Proofs.org
+++ b/03_Propositions_and_Proofs.org
@@ -808,7 +808,6 @@ example : p ∨ (q ∧ r) ↔ (p ∨ q) ∧ (p ∨ r) := sorry
 -- other properties
 example : (p → (q → r)) ↔ (p ∧ q → r) := sorry
 example : ((p ∨ q) → r) ↔ (p → r) ∧ (q → r) := sorry
-example : (p → r ∨ s) → ((p → r) ∨ (p → s)) := sorry
 example : ¬(p ∨ q) ↔ ¬p ∧ ¬q := sorry
 example : ¬p ∨ ¬q → ¬(p ∧ q) := sorry
 example : ¬(p ∧ ¬ p) := sorry


### PR DESCRIPTION
The tutorial states that exercises requiring classical reasoning are
grouped at the end; this exercise is repeated twice, and appears in the
wrong group.