### PR TITLE
fix(04): typos

### DIFF
--- a/04_Quantifiers_and_Equality.org
+++ b/04_Quantifiers_and_Equality.org
@@ -163,7 +163,7 @@ direction of the second of these requires classical logic):
 variables (A : Type) (p q : A → Prop)
 variable r : Prop
 
-example : A → (∀ x : A, r) ↔ r := sorry
+example : A → ((∀ x : A, r) ↔ r) := sorry
 example : (∀ x, p x ∨ r) ↔ (∀ x, p x) ∨ r := sorry
 example : (∀ x, r → p x) ↔ (r → ∀ x, p x) := sorry
 #+END_SRC


### PR DESCRIPTION
I believe the parentheses are necessary here, otherwise the exercise is
impossible.  (It amounts to showing r from just A -> r, knowing nothing
of A.)