### PR TITLE
housecleaning

### DIFF
--- a/02_Dependent_Type_Theory.org
+++ b/02_Dependent_Type_Theory.org
@@ -448,7 +448,7 @@ eval b && ff         -- ff
 print "reducing arithmetic expressions"
 eval n + 0           -- n
 eval n + 2           -- succ (succ n)
-eval 2 + 3           -- 5
+eval (2 : nat) + 3   -- 5
 #+END_SRC
 In a later chapter, we will explain how these terms are evaluated. For
 now, we only wish to emphasize that this is an important feature of

--- a/02_Dependent_Type_Theory.org
+++ b/02_Dependent_Type_Theory.org
@@ -1131,39 +1131,41 @@ All that has changed are the braces around =A : Type= in the
 declaration of the variables. We can also use this device in function
 definitions:
 #+BEGIN_SRC lean
-definition id {A : Type} (x : A) := x
+definition ident {A : Type} (x : A) := x
 
-check id      -- ?A → ?A
+check ident      -- ?A → ?A
 
 variables A B : Type
 variables (a : A) (b : B)
 
-check id      -- ?A A B a b → ?A A B a b
-check id a    -- A 
-check id b    -- B
+check ident      -- ?A A B a b → ?A A B a b
+check ident a    -- A 
+check ident b    -- B
 #+END_SRC
-This makes the first argument to =id= implicit. Notationally, this
-hides the specification of the type, making it look as though =id=
-simply takes an argument of any type. 
+This makes the first argument to =ident= implicit. Notationally, this
+hides the specification of the type, making it look as though =ident=
+simply takes an argument of any type. In fact, the function =id= is
+defined in the standard library in exactly this way. We have chosen
+a nontraditional name here only to avoid a clash of names.
 
 In the first =check= command, the inscription =?A= indicates that the
-type of =id= depends on a "placeholder," or "metavariable," that
+type of =ident= depends on a "placeholder," or "metavariable," that
 should, in general, be inferred from the context. The output of the
 second =check= command is somewhat verbose: it indicates that the
 placeholder, =?A=, can itself depend on any of the variables =A=, =B=,
 =a=, and =b= that are in the context. If this additional information
-is annoying, you can suppress it by writing =@id=, as described
-below. Alternatively, you can set an option to avoid pointing these
+is annoying, you can suppress it by writing =@ident=, as described
+below. Alternatively, you can set an option to avoident pointing these
 arguments:
 #+BEGIN_SRC lean
-definition id {A : Type} (x : A) := x
+definition ident {A : Type} (x : A) := x
 
 -- BEGIN
 variables A B : Type
 variables (a : A) (b : B)
 
 set_option pp.metavar_args false
-check id      -- ?A → ?A
+check ident      -- ?A → ?A
 -- END
 #+END_SRC
 
@@ -1173,17 +1175,17 @@ the =variables= command:
 section
   variable {A : Type}
   variable x : A
-  definition id := x
+  definition ident := x
 end
 
 variables A B : Type
 variables (a : A) (b : B)
 
-check id
-check id a
-check id b
+check ident
+check ident a
+check ident b
 #+END_SRC
-This definition of =id= has the same effect as the one above.
+This definition of =ident= has the same effect as the one above.
 
 Lean has very complex mechanisms for instantiating implicit arguments,
 and we will see that they can be used to infer function types,
@@ -1199,20 +1201,20 @@ provide the argument explicitly. If =foo= is such a function, the
 notation =@foo= denotes the same function with all the arguments made
 explicit.
 #+BEGIN_SRC lean
-definition id {A : Type} (x : A) := x
+definition ident {A : Type} (x : A) := x
 
 variables A B : Type
 variables (a : A) (b : B)
 -- BEGIN
-check @id        -- Π {A : Type}, A → A
-check @id A      -- A → A
-check @id B      -- B → B
-check @id A a    -- A
-check @id B b    -- B
+check @ident        -- Π {A : Type}, A → A
+check @ident A      -- A → A
+check @ident B      -- B → B
+check @ident A a    -- A
+check @ident B b    -- B
 -- END
 #+END_SRC
 Notice that now the first =check= command gives the type of the
-identifier, =id=, without inserting any placeholders. Moreover, the
+identifier, =ident=, without inserting any placeholders. Moreover, the
 output indicates that the first argument is implicit.
 
 Section [[file:08_Building_Theories_and_Proof::#More_on_Implicit_Arguments][More on Implicit Arguments]] explains another useful annotation,

--- a/04_Quantifiers_and_Equality.org
+++ b/04_Quantifiers_and_Equality.org
@@ -818,8 +818,39 @@ exists.intro x
 -- END
 #+END_SRC
 
-# Soonho: The following paragraph and lean code block are commented out.
-#         Plase see the discussion at https://github.com/leanprover/tutorial/issues/138
+The following proof that the square root of two is irrational can be
+found in the standard library. It provides a nice example of the way that
+proof terms can be structured and made readable using the devices we have
+discussed here.
+#+BEGIN_SRC lean
+open nat algebra
+  
+theorem sqrt_two_irrational {a b : ℕ} (co : coprime a b) : a^2 ≠ 2 * b^2 :=
+assume H : a^2 = 2 * b^2,
+have even (a^2),
+  from even_of_exists (exists.intro _ H),
+have even a,
+  from even_of_even_pow this,
+obtain (c : nat) (aeq : a = 2 * c),
+  from exists_of_even this,
+have 2 * (2 * c^2) = 2 * b^2,
+  by rewrite [-H, aeq, *pow_two, mul.assoc, mul.left_comm c],
+have 2 * c^2 = b^2,
+  from eq_of_mul_eq_mul_left dec_trivial this,
+have even (b^2),
+  from even_of_exists (exists.intro _ (eq.symm this)),
+have even b,
+  from even_of_even_pow this,
+have 2 ∣ gcd a b,
+  from dvd_gcd (dvd_of_even `even a`) (dvd_of_even `even b`),
+have 2 ∣ 1,
+  begin+ rewrite [gcd_eq_one_of_coprime co at this], exact this end,
+show false, from absurd `2 ∣ 1` dec_trivial
+#+END_SRC
+
+# A previously used example is found below. We had to reject it because
+# we cannot currently include primes.lean in the web version of Lean. 
+# See the discussion at https://github.com/leanprover/tutorial/issues/138.
 #
 # The following proof that there are infinitely many primes is a slight
 # variant of the proof in the standard library. It provides a nice

--- a/04_Quantifiers_and_Equality.org
+++ b/04_Quantifiers_and_Equality.org
@@ -578,10 +578,11 @@ require some form of classical reasoning.
 open classical
 
 variables (A : Type) (p q : A → Prop)
+variable a : A
 variable r : Prop
 
 example : (∃ x : A, r) → r := sorry
-example (a : A) : r → (∃ x : A, r) := sorry
+example : r → (∃ x : A, r) := sorry
 example : (∃ x, p x ∧ r) ↔ (∃ x, p x) ∧ r := sorry
 example : (∃ x, p x ∨ q x) ↔ (∃ x, p x) ∨ (∃ x, q x) := sorry
 
@@ -591,15 +592,19 @@ example : (¬ ∃ x, p x) ↔ (∀ x, ¬ p x) := sorry
 example : (¬ ∀ x, p x) ↔ (∃ x, ¬ p x) := sorry
 
 example : (∀ x, p x → r) ↔ (∃ x, p x) → r := sorry
-example (a : A) : (∃ x, p x → r) ↔ (∀ x, p x) → r := sorry
-example (a : A) : (∃ x, r → p x) ↔ (r → ∃ x, p x) := sorry
+example : (∃ x, p x → r) ↔ (∀ x, p x) → r := sorry
+example : (∃ x, r → p x) ↔ (r → ∃ x, p x) := sorry
 #+END_SRC
+Notice that the declaration =variable a : A= amounts to the assumption
+that there is at least one element of type =A=. This assumption is
+needed in the second example, as well as in the last two.
 
 Here are solutions to two of the more difficult ones:
 #+BEGIN_SRC lean
 open classical
 
 variables (A : Type) (p q : A → Prop)
+variable a : A
 variable r : Prop
 
 -- BEGIN
@@ -619,12 +624,12 @@ iff.intro
         obtain a Hqa, from Hq,
         exists.intro a (or.inr Hqa)))
 
-example (a : A) : (∃ x, p x → r) ↔ (∀ x, p x) → r :=
+example : (∃ x, p x → r) ↔ (∀ x, p x) → r :=
 iff.intro
   (assume H1 : ∃ x, p x → r,
     assume H2 : ∀ x, p x,
-    obtain a (Ha : p a → r), from H1,
-    show r, from  Ha (H2 a))
+    obtain b (Hb : p b → r), from H1,
+    show r, from  Hb (H2 b))
   (assume H1 : (∀ x, p x) → r,
     show ∃ x, p x → r, from
       by_cases

--- a/05_Interacting_with_Lean.org
+++ b/05_Interacting_with_Lean.org
@@ -585,7 +585,7 @@ attribute:
 import data.nat
 open nat
 
-notation [parsing-only] `[` a `**` b `]` := a * b + 1
+notation [parsing_only] `[` a `**` b `]` := a * b + 1
 
 variables a b : ℕ
 check [a ** b]

--- a/05_Interacting_with_Lean.org
+++ b/05_Interacting_with_Lean.org
@@ -589,7 +589,7 @@ notation [parsing_only] `[` a `**` b `]` := a * b + 1
 
 variables a b : ℕ
 check [a ** b]
-#+END_SRC
++END_SRC
 The output of the =check= command displays the expression as =a * b +
 1=. Lean also provides mechanisms for iterated notation, such as =[a,
 b, c, d, e]= to denote a list with the indicated elements. See the
@@ -629,7 +629,7 @@ print notation +
 #+END_SRC
 Nonetheless, you might decide to overload the plus symbol and
 use it for the list "append" function as well:
-#+BEGIN_SRC list
+#+BEGIN_SRC lean
 import data.nat data.list
 open algebra nat list
 

--- a/05_Interacting_with_Lean.org
+++ b/05_Interacting_with_Lean.org
@@ -72,9 +72,8 @@ print classes                : display all classes
 print instances <class name> : display all instances of the given class
 print fields <structure>     : display all "fields" of a structure
 #+END_SRC
-We will discuss classes, instances, and structures in Chapter
-[[file:09_Type_Classes.org::#Type_Classes][Type Classes]]. Here are
-examples of how the =print= commands are used:
+We will discuss classes, instances, and structures in Chapter [[file:09_Type_Classes.org::#Type_Classes][Type
+Classes]]. Here are examples of how the =print= commands are used:
 #+BEGIN_SRC lean
 import standard algebra.ring
 open prod sum int nat algebra
@@ -579,39 +578,91 @@ You are welcome to overload these symbols for your own use, but you
 cannot change their right-binding power.
 
 Remember that you can direct the pretty-printer to suppress notation
-with the command =set_option pp.notation false=. 
-# You can also declare
-# notation to be used for input purposes only with the =[parsing-only]=
-# attribute:
-# #+BEGIN_SRC lean
-# import data.nat
-# open nat
+with the command =set_option pp.notation false=.  You can also declare
+notation to be used for input purposes only with the =[parsing_only]=
+attribute:
+#+BEGIN_SRC lean
+import data.nat
+open nat
 
-# notation [parsing-only] `[` a `**` b `]` := a * b + 1
+notation [parsing-only] `[` a `**` b `]` := a * b + 1
 
-# variables a b : ℕ
-# check [a ** b]
-# #+END_SRC
-# The output of the =check= command displays the expression as =a * b +
-# 1=. 
-Lean also provides mechanisms for iterated notation, such as =[a, b,
-c, d, e]= to denote a list with the indicated elements. See the
+variables a b : ℕ
+check [a ** b]
+#+END_SRC
+The output of the =check= command displays the expression as =a * b +
+1=. Lean also provides mechanisms for iterated notation, such as =[a,
+b, c, d, e]= to denote a list with the indicated elements. See the
 discussion of =list= in the next chapter for an example.
 
 Notation in Lean can be /overloaded/, which is to say, the same
 notation can be used for more than one purpose. In that case, Lean's
-elaborator will try to disambiguate based on context.
+elaborator will try to disambiguate based on context. For example, we
+have already seen that with the =eq.ops= namespace open, the inverse
+symbol can be used to denote the symmetric form of an equality. It can
+also be used to denote the multiplicative inverse:
+#+BEGIN_SRC lean
+import data.rat
+open rat eq.ops
+
+variable r : ℚ
+
+check r⁻¹             -- ℚ
+check (eq.refl r)⁻¹   -- r = r
+#+END_SRC
+Insofar as overloads produce ambiguity, they should be used
+sparingly. We avoid the use of overloads for arithmetic operations
+like =+=, =*=, =-=, and =/= using /type classes/, as described in
+Chapter [[file:09_Type_Classes.org::#Type_Classes][Type Classes]]. For example, in the following, the addition
+operation denotes a general algebraic operation, that can be
+instantiated to =nat= or =int= as required:
 #+BEGIN_SRC lean
 import data.nat data.int
-open nat int
+open algebra nat int
 
 variables a b : int
 variables m n : nat
 
-check a + b
-check m + n
+check a + b    -- ℕ 
+check m + n    -- ℤ
 print notation +
 #+END_SRC
+Nonetheless, you might decide to overload the plus symbol and
+use it for the list "append" function as well:
+#+BEGIN_SRC list
+import data.nat data.list
+open algebra nat list
+
+variables m n : ℕ
+variables s t : list ℕ
+
+infix + := list.append
+
+check m + n   -- ℕ
+check s + t   -- list ℕ
+#END_SRC
+Where it is necessary to disambiguate, Lean allows you to precede an
+expression with the notation =#<namespace>=, to specify the namespace 
+in which notation is to be interpreted. 
+#+BEGIN_SRC lean
+import data.nat data.list
+open algebra nat list
+
+variables m n : ℕ
+variables s t : list ℕ
+
+infix + := list.append
+
+check m + n   -- ℕ
+check s + t   -- list ℕ
+
+-- BEGIN
+check λ x y, (#algebra x + y)
+check λ x y, (#list x + y)
+-- END
+#+END_SRC
+In the first case, the addition symbol is polymorphic over structures
+which have an associated addition operation.
 
 Lean provides an =abbreviation= mechanism that is similar to the
 notation mechanism.
@@ -682,13 +733,13 @@ check a + 123        -- a + of_nat (of_num 123) : ℤ
 Setting the option =pp.coercions= to =true= makes the coercions
 explicit. Coercions that are declared in a namespace are only
 available to the system when the namespace is opened. The notation
-=(t : T)= is an abbreviation for the expression =is_typeof T t=, where
-=is_typeof= is nothing more than fancy notation for the identity
-function. The point is that =T= is given explicitly, so that when you
-write =(t : T)=, you are specifying that =t= should be interpreted as
-an expression of type =T=. In the first =check= command, Lean decides
-that =123= is a numeral. The two commands after than indicate that it
-is intended to be viewed as a =nat= and as an =int=, respectively.
+=(t : T)= constrains Lean to find an interpertation of =t= which gives
+it a type that is definitionally equal to =T=, thereby allowing you to
+specify the interpretation of =t= you have in mind. In the first
+=check= command, =123= is a generic numeral, which can be instantiated
+to any type that has a =0=, =1=, and addition. The two commands after
+that indicate that it is intended to be viewed as a =nat= and as an
+=int=, respectively.
 
 Here is an example of how we can define a coercion from the booleans
 to the natural numbers.
@@ -762,6 +813,8 @@ notation =#<namespace>=, to specify the namespace in which notation is
 to be interpreted. Another is to replace the notation with an explicit
 function name. Yet a third is to use the =(t : T)= notation to indicate
 the intended type.
+
+#
 # #+BEGIN_SRC lean
 # import data.nat data.int
 # open nat int

--- a/08_Building_Theories_and_Proofs.org
+++ b/08_Building_Theories_and_Proofs.org
@@ -653,14 +653,12 @@ definition pr1 [reducible] (A : Type) (a b : A) : A := a
 The assignment persists to other modules. You can achieve the same
 result with the =attribute= command:
 #+BEGIN_SRC lean
-definition id (A : Type) (a : A) : A := a
 definition pr2 (A : Type) (a b : A) : A := b
 
 -- mark pr2 as reducible
 attribute pr2 [reducible]
 
--- mark id and pr2 as irreducible
-attribute id [irreducible]
+-- mark pr2 as irreducible
 attribute pr2 [irreducible]
 #+END_SRC
 

--- a/09_Type_Classes.org
+++ b/09_Type_Classes.org
@@ -848,11 +848,11 @@ foo.mk 3 3
 
 example : foo.a = 3 := rfl
 
-attribute i3 [priority 500]
+attribute i3 [instance] [priority 500]
 
 example : foo.a = 1 := rfl
 
-attribute i1 [priority std.priority.default-10]
+attribute i1 [instance] [priority std.priority.default-10]
 
 example : foo.a = 2 := rfl
 #+END_SRC

--- a/10_Structures_and_Records.org
+++ b/10_Structures_and_Records.org
@@ -84,8 +84,8 @@ structure point (A : Type) :=
 mk :: (x : A) (y : A)
 
 -- BEGIN
-eval point.x (point.mk 10 20)
-eval point.y (point.mk 10 20)
+eval point.x (point.mk (10 : ℕ) 20)
+eval point.y (point.mk (10 : ℕ) 20)
 
 open point
 
@@ -168,10 +168,10 @@ rfl
 #+END_SRC
 
 Note that =point= is a parametric type, but we did not provide its
-parameters. Here, in each case, Lean infers that we are constructing an
-object of type =point ℕ= from the fact that one of the components is specified
-to be of type =ℕ=. Alternatively, we can exOf course,
-the parameters can be explicitly provided with the type if needed.
+parameters. Here, in each case, Lean infers that we are constructing
+an object of type =point ℕ= from the fact that one of the components
+is specified to be of type =ℕ=. Of course, the parameters can be
+explicitly provided with the type if needed.
 #+BEGIN_SRC lean
 open nat
 

--- a/A1_Quick_Reference.org
+++ b/A1_Quick_Reference.org
@@ -107,21 +107,23 @@ type in the context with a hidden name.
 *** Tactic Mode
 
 At any point in a proof or definition you can switch to tactic mode and apply tactics to 
-finish that part of the proof or definition
+finish that part of the proof or definition.
 
 #+BEGIN_SRC text
 begin ... end   : enter tactic mode, and blocking mechanism within tactic mode
 { ... }         : blocking mechanism within tactic mode
 by ...          : enter tactic mode, can only execute a single tactic
-begin+; by+     : normally entering tactic mode will make declarations in the local context 
-                  given by "have"-expressions unavailable. Entering tactic mode with these
-                  will make all declarations available
+begin+; by+     : same as =begin= and =by=, but make local results available
 have            : as in term mode (enters term mode), but visible to tactics
 assert          : as in term mode (stays in tactic mode)
 show            : as in term mode (enters term mode)
 match ... with  : as in term mode (enters term mode)
 let             : introduce local fact (opaque, in the body)
 #+END_SRC
+
+Normally, entering tactic mode will make declarations in the local
+context given by "have"-expressions unavailable. The annotations
+=begin+= and =by+= make all these declarations available.
 
 ** Sectioning Mechanisms
 


### PR DESCRIPTION
This is a scattered list of small fixes and corrections, including corrections that adapt to recent changes in the library. 

The description of `proof ... qed` in Chapter 8 is no longer correct, because that is now implemented with `by+`. I think the solution is to move the whole section on making `have` assertions visible should be moved to the tactics chapter, but I want to read through the whole text to make sure that will work.

@cjmazey I'd like to acknowledge your contributions (there is a list of people we thank in the introduction). If that's o.k., let me know your name!

Some things broke in the tutorial because `id` is now declared at top level. I switched to `ident` in an example. Also, in Chapter  9, for example, 
```lean
attribute i3 [instance] [priority 500]
```
had to be replaced by
```lean
attribute i3 [priority 500]
```
From the error message, it seems that `priority` can now be applied to other things as well, like `simp` and `backward` rules.
